### PR TITLE
Add DisplayVersion, VersionMajor and VersionMinor to uninstall HKCU

### DIFF
--- a/setup/WDS.nsi
+++ b/setup/WDS.nsi
@@ -267,6 +267,7 @@ Function CreateUninstallEntry
   WriteRegExpandStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "InstallLocation" "$INSTDIR"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "DisplayName" "${sVersionFull}"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "DisplayIcon" "$INSTDIR\windirstat.exe,0"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "DisplayVersion" "${dVersionMajor}.${dVersionMinor}.${dVersionRev}"
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "dwVersionMajor" "${dVersionMajor}"
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "dwVersionMinor" "${dVersionMinor}"
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "dwVersionRev" "${dVersionRev}"

--- a/setup/WDS.nsi
+++ b/setup/WDS.nsi
@@ -268,6 +268,8 @@ Function CreateUninstallEntry
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "DisplayName" "${sVersionFull}"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "DisplayIcon" "$INSTDIR\windirstat.exe,0"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "DisplayVersion" "${dVersionMajor}.${dVersionMinor}.${dVersionRev}"
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "VersionMajor" "${dVersionMajor}"
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "VersionMinor" "${dVersionMinor}"
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "dwVersionMajor" "${dVersionMajor}"
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "dwVersionMinor" "${dVersionMinor}"
   WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat" "dwVersionRev" "${dVersionRev}"


### PR DESCRIPTION
Copy of PR #2 by @frehov 
Additionally added `VersionMajor` and `VersionMinor`.

Original pr:
> Minor convenience fix for users of winget.
> 
> Sets the String `DisplayVersion` to the current full version in the uninstaller registry hive located at `HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall\WinDirStat`
> 
> Reason for change. Winget can currently install windirstat, but loses track immediately of the version and relies upon the version being available on the uninstaller entry under the key `DisplayVersion`
> 
> Change has been tested locally by adding the registry key manually and verifying that winget now lists the version when listing installed apps. Change has been verified by setting a lower version (1.1.1) and verifying that winget upgrade includes windirstat 1.1.2 as an available upgrade.
> 
> ![image](https://user-images.githubusercontent.com/37329363/215227134-e4a26d08-6df4-4167-914d-82b9b3bbb605.png)