### PR TITLE
partially re-enable checking compressed file size

### DIFF
--- a/windirstat/FileFindWDS.cpp
+++ b/windirstat/FileFindWDS.cpp
@@ -42,23 +42,24 @@ DWORD CFileFindWDS::GetAttributes() const
 // Wrapper for file size retrieval
 // This function tries to return compressed file size whenever possible.
 // If the file is not compressed the uncompressed size is being returned.
-ULONGLONG CFileFindWDS::GetCompressedLength() const
+ULONGLONG CFileFindWDS::GetCompressedLength(DWORD FileAttributes) const
 {
-#if 0 // TODO: make this an option (the compressed size instead of "normal" size
-    ULARGE_INTEGER ret;
-    ret.LowPart = ::GetCompressedFileSize(GetFilePath(), &ret.HighPart);
+    // if it is possible for disk-size to differ from reported-size
+    if (FileAttributes & (FILE_ATTRIBUTE_COMPRESSED | FILE_ATTRIBUTE_SPARSE_FILE)) {
+        ULARGE_INTEGER ret;
+        ret.LowPart = ::GetCompressedFileSize(GetFilePath(), &ret.HighPart);
 
-    // Check for error
-    if((::GetLastError() != ERROR_SUCCESS) && (ret.LowPart == INVALID_FILE_SIZE))
-    {
-        // In case of an error return size from CFileFind object
-        return GetLength();
-    }
-    else
-    {
-        return ret.QuadPart;
-    }
-#endif // 0
+        // Check for error
+        if ((::GetLastError() != ERROR_SUCCESS) && (ret.LowPart == INVALID_FILE_SIZE))
+        {
+            // In case of an error return size from CFileFind object
+            return GetLength();
+        }
+        else
+        {
+            return ret.QuadPart;
+        }
+    } 
     // Use the file size already found by the finder object
     return GetLength();
 }

--- a/windirstat/FileFindWDS.h
+++ b/windirstat/FileFindWDS.h
@@ -28,7 +28,7 @@ class CFileFindWDS : public CFileFind
 {
 public:
     DWORD GetAttributes() const;
-    ULONGLONG GetCompressedLength() const;
+    ULONGLONG GetCompressedLength(DWORD FileAttributes) const;
 };
 
 #endif // __WDS_FILEFINDWDS_H__

--- a/windirstat/item.cpp
+++ b/windirstat/item.cpp
@@ -1100,7 +1100,7 @@ void CItem::DoSomeWork(CWorkLimiter* limiter)
                     fi.name = finder.GetFileName();
                     fi.attributes = finder.GetAttributes();
                     // Retrieve file size
-                    fi.length = finder.GetCompressedLength();
+                    fi.length = finder.GetCompressedLength(fi.attributes);
                     finder.GetLastWriteTime(&fi.lastWriteTime);
                     // (We don't use GetLastWriteTime(CTime&) here, because, if the file has
                     // an invalid timestamp, that function would ASSERT and throw an Exception.)
@@ -1261,7 +1261,7 @@ bool CItem::StartRefresh()
             fi.name = finder.GetFileName();
             fi.attributes = finder.GetAttributes();
             // Retrieve file size
-            fi.length = finder.GetCompressedLength();
+            fi.length = finder.GetCompressedLength(fi.attributes);
             finder.GetLastWriteTime(&fi.lastWriteTime);
 
             AddFile(fi);
@@ -1320,7 +1320,7 @@ bool CItem::StartRefresh()
                 fi.name = finder.GetFileName();
                 fi.attributes = finder.GetAttributes();
                 // Retrieve file size
-                fi.length = finder.GetCompressedLength();
+                fi.length = finder.GetCompressedLength(fi.attributes);
                 finder.GetLastWriteTime(&fi.lastWriteTime);
 
                 SetLastChange(fi.lastWriteTime);


### PR DESCRIPTION
this PR enables GetCompressedFileSize, but only uses it when the File Attributes say the file could return a different compressed size. 

https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getcompressedfilesizea says GetCompressedFileSize reports different size for compressed or sparse files, so lets check for those flags.

On my laptop there is perhaps a 15% slowdown in  runtime - an example below shows 22 second vs 24 seconds when considering a 1GB difference in 1.6TB/1.3 million files
(most of the time is spent "suspended" according to the bottom bar, and the code without this modification sometimes takes longer than the code without this modification)

Comparison of such a run (main branch top, my PR below - note the updated size is 0.9 GB smaller, accounting for sparse/compressed files.

![image](https://github.com/windirstat/windirstat/assets/1892829/95906916-7eac-4d3e-a0d3-31c2024185fd)
