### PR TITLE
Automation with winget-releaser to publish betas and releases

### DIFF
--- a/.github/workflows/publish-betas-to-winget-pkgs.yml
+++ b/.github/workflows/publish-betas-to-winget-pkgs.yml
@@ -1,0 +1,21 @@
+name: Publish betas to WinGet
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Get version
+        id: get-version
+        run: |
+          # Finding the version from release name
+          $VERSION="${{ github.ref_name }}" -ireplace '^beta/v?' -ireplace '/', '.'
+          "version=$VERSION" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: WinDirStat.WinDirStat.Beta
+          version: ${{ steps.get-version.outputs.version }}
+          installers-regex: '\.msi$' # Only .msi files
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/.github/workflows/publish-releases-to-winget-pkgs.yml
+++ b/.github/workflows/publish-releases-to-winget-pkgs.yml
@@ -1,0 +1,21 @@
+name: Publish releases to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Get version
+        id: get-version
+        run: |
+          # Finding the version from release name
+          $VERSION="${{ github.ref_name }}" -ireplace '^release/v?'
+          "version=$VERSION" >> $env:GITHUB_OUTPUT
+        shell: pwsh
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: WinDirStat.WinDirStat
+          version: ${{ steps.get-version.outputs.version }}
+          installers-regex: '\.msi$' # Only .msi files
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This adds two GitHub actions. I already added the necessary personal access token as secret `WINGET_TOKEN`, so this should work.

Here's the way it's supposed to work.

* tags of the form `beta/v9.8.7/2999-12-31` should end up as `9.8.7.2999-12-31` in the manifest
* tags of the form `release/v9.8.7` should end up as `9.8.7` in the manifest

Matching is case-insensitive.

There's just one uncertainty (at least as long as we use winget-releaser and not Komac directly): will the fact that you create a _release_ also cause the GitHub action for the _beta_ to trigger? We already talked about this. I'll try to dig up a solution, but I currently don't have one.

However, given that we ourselves can go ahead and close the PR that gets created by the actions, the risk is manageable at least.

--------

I dry-tested this with Komac (Bash) and it works beautifully:

```
$ komac update WinDirStat.WinDirStat.Beta --version 2.0.0.2024-10-12 --urls https://github.com/windirstat/windirstat/releases/download/beta%2Fv2.0.0%2F2024-10-10/WinDirStat-{arm,arm64,x64,x86}.msi
```
