### PR TITLE
Fix auto-size truncation and adjust column padding

### DIFF
--- a/windirstat/Controls/OwnerDrawnListControl.cpp
+++ b/windirstat/Controls/OwnerDrawnListControl.cpp
@@ -508,7 +508,7 @@ bool COwnerDrawnListControl::IsShowSelectionAlways() const
 int COwnerDrawnListControl::GetSubItemWidth(COwnerDrawnListItem* item, const int subitem)
 {
     CClientDC dc(this);
-    CRect rc(0, 0, 1000, 1000);
+    CRect rc(0, 0, 3500, 20);
 
     int width;
     int dummy = rc.left;
@@ -591,13 +591,14 @@ void COwnerDrawnListControl::OnHdnDividerdblclick(NMHDR* pNMHDR, LRESULT* pResul
 {
     const int column = reinterpret_cast<LPNMHEADER>(pNMHDR)->iItem;
     const int subitem = ColumnToSubItem(column);
+    const int padding = 3;
 
     int width = 10;
     for (int i = 0, itemMax = GetItemCount(); i < itemMax; i++)
     {
         width = max(width, GetSubItemWidth(GetItem(i), subitem));
     }
-    SetColumnWidth(column, width + 5);
+    SetColumnWidth(column, width + padding);
 
     *pResult = FALSE;
 }

--- a/windirstat/Controls/TreeListControl.cpp
+++ b/windirstat/Controls/TreeListControl.cpp
@@ -706,9 +706,10 @@ void CTreeListControl::ExpandItem(const int i, const bool scroll)
     UnlockWindowUpdate();
     SetRedraw(TRUE);
 
+    const int padding = 3;
     if (scroll && GetColumnWidth(0) < maxwidth)
     {
-        SetColumnWidth(0, maxwidth);
+        SetColumnWidth(0, maxwidth + padding);
     }
 
     item->SetExpanded(true);


### PR DESCRIPTION
- Increase GetSubItemWidth measurement width to 3500 to prevent truncation of very long file name
- Change column padding from 5px to 3px
- Add 3px padding to Auto Resize Columns function to prevent truncation