### PR TITLE
Auto Reduce Frequent Reallocations In Path Construction

### DIFF
--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -1517,6 +1517,9 @@ void CDirStatDoc::StartScanningEngine(std::vector<CItem*> items)
     // Stop any previous executions
     StopScanningEngine();
 
+    //Reset Path Construction Cache Size to Default
+    CDirStatApp::Get()->ResetMaxPathPartsSizeCache();
+
     // Address currently zoomed / selected item conflicts
     const auto zoomItem = GetZoomItem();
     for (const auto& item : std::vector(items))

--- a/windirstat/Item.cpp
+++ b/windirstat/Item.cpp
@@ -1380,7 +1380,7 @@ std::wstring CItem::UpwardGetPathWithoutBackslash() const
     std::vector<const CItem*> pathParts;
 
     // preallocate some space to avoid multiple re-allocations
-    pathParts.resize(8);
+    pathParts.reserve(CDirStatApp::Get()->GetMaxPathPartsSize());
 
     // walk backwards to get a list of pointers to each part of the path
     std::size_t estSize = 0;
@@ -1389,6 +1389,7 @@ std::wstring CItem::UpwardGetPathWithoutBackslash() const
         pathParts.emplace_back(p);
         estSize += p->m_Name.length() + 1;
     }
+    CDirStatApp::Get()->SetMaxPathPartsSize(pathParts.size());
 
     // append the strings in reverse order
     std::wstring path;

--- a/windirstat/WinDirStat.cpp
+++ b/windirstat/WinDirStat.cpp
@@ -124,6 +124,22 @@ std::tuple<ULONGLONG, ULONGLONG> CDirStatApp::GetFreeDiskSpace(const std::wstrin
     return { u64total.QuadPart, u64free.QuadPart };
 }
 
+void CDirStatApp::SetMaxPathPartsSize(size_t size)
+{
+    size_t current_max = s_maxPathPartsSize.load();
+
+    // Use a Compare-and-Swap (CAS) loop to safely update the maximum across threads.
+    while (size > current_max)
+    {
+        // Atomically tries to replace current_max with size.
+        // If it fails (due to another thread), current_max is updated and the loop retries.
+        if (s_maxPathPartsSize.compare_exchange_weak(current_max, size))
+        {
+            break;
+        }
+    }
+}
+
 bool CDirStatApp::IsFollowingAllowed(const DWORD reparseTag) const
 {
     if (reparseTag == 0) return true;

--- a/windirstat/WinDirStat.h
+++ b/windirstat/WinDirStat.h
@@ -24,6 +24,7 @@
 #include "IconHandler.h"
 #include "Constants.h"
 #include "Tracer.h"
+#include <atomic>
 
 class CMainFrame;
 class CDirStatApp;
@@ -60,6 +61,9 @@ public:
 
     static std::tuple<ULONGLONG, ULONGLONG> GetFreeDiskSpace(const std::wstring& pszRootPath);
     static CDirStatApp* Get() { return &_singleton; }
+    size_t GetMaxPathPartsSize() const { return s_maxPathPartsSize.load(); }
+    void SetMaxPathPartsSize(size_t size);
+    void ResetMaxPathPartsSizeCache() { s_maxPathPartsSize = s_defaultMaxPathPartsSize; }
 
 protected:
 
@@ -72,6 +76,9 @@ protected:
     COLORREF m_AltColor;              // Coloring of compressed items
     COLORREF m_AltEncryptionColor;    // Coloring of encrypted items
     static CDirStatApp _singleton;    // Singleton application instance
+    const size_t s_defaultMaxPathPartsSize = 8; // Can be defined right here
+    std::atomic<size_t> s_maxPathPartsSize = s_defaultMaxPathPartsSize;
+
 #ifdef VTRACE_TO_CONSOLE
     CAutoPtr<CWDSTracerConsole> m_VtraceConsole;
 #endif // VTRACE_TO_CONSOLE


### PR DESCRIPTION
- Implement self-tuning cache for maximum path depth to auto reduce memory reallocation overhead in path construction
- Change pathParts vector initialization from resize(8) to reserve(MaxPathPartsSize)
- Use std::atomic<size_t> with Compare-and-Swap (CAS) logic for MaxPathPartsSize to ensure thread safety during concurrent scanning
- Reset MaxPathPartsSize cache to default at the start of every new scan