### PR TITLE
Add github workflow to easily build Windirstat between releases

### DIFF
--- a/.github/workflows/build-windirstat.yml
+++ b/.github/workflows/build-windirstat.yml
@@ -8,7 +8,7 @@ on:
       reltype:
         description: 'Release type'
         required: false
-        default: 'production'
+        default: 'beta'
         type: choice
         options:
           - production


### PR DESCRIPTION
Simple workflow that builds windirstat. Making for easier testing of commits between releases without the need to pull and build locally.