### PR TITLE
Fix checkbox label color in dark mode

### DIFF
--- a/windirstat/DarkMode.cpp
+++ b/windirstat/DarkMode.cpp
@@ -146,7 +146,8 @@ void DarkMode::AdjustControls(const HWND hWnd)
         if (className == WC_BUTTON)
         {
             const auto style = GetWindowLong(hWnd, GWL_STYLE) & BS_TYPEMASK;
-            if (style == BS_GROUPBOX || style == BS_RADIOBUTTON || style == BS_AUTORADIOBUTTON)
+            if (style == BS_GROUPBOX || style == BS_RADIOBUTTON || style == BS_AUTORADIOBUTTON ||
+                style == BS_CHECKBOX || style == BS_AUTOCHECKBOX)
             {
                 SetWindowTheme(hWnd, _darkModeEnabled ? L"DarkMode_Explorer" : L"Explorer", L"");
             }


### PR DESCRIPTION
Credit: Google Gemini guided patch

## Prompt

The labels of the radio buttons already in correct color before changing anything

## Response

That's very helpful information\! If the **radio button labels** are already in the correct light color, it means your existing code is successfully handling:

1.  **Radio Button Styles:** `BS_RADIOBUTTON` and `BS_AUTORADIOBUTTON`.
2.  **Group Box Styles:** `BS_GROUPBOX` (which often contains the radio buttons).

This confirms that the existing logic for handling these specific button types in `DarkMode::AdjustControls` is correct for setting up the text color.

Since the **Checkbox labels are black**, but the **Radio Button labels are correct**, this points to a specific gap in how you are applying the theme override for the **Checkbox control styles**.

-----

## 🧐 Focused Analysis: Checkbox vs. Radio Button Logic

Let's look closely at your existing `DarkMode::AdjustControls` logic to identify where the radio button styles are handled, and how we need to extend that to include the checkbox styles.

### 1\. The Current Successful Logic (Radio Buttons)

Your code that successfully allows radio buttons to use the correct color is this:

```cpp
// From DarkMode::AdjustControls
if (className == WC_BUTTON)
{
    const auto style = GetWindowLong(hWnd, GWL_STYLE) & BS_TYPEMASK;
    if (style == BS_GROUPBOX || style == BS_RADIOBUTTON || style == BS_AUTORADIOBUTTON)
    {
        // This line is likely disabling the Windows Theme for these controls,
        // allowing the WM_CTLCOLORSTATIC/WM_CTLCOLORBTN message to apply the color.
        SetWindowTheme(hWnd, _darkModeEnabled ? L"DarkMode_Explorer" : L"Explorer", L""); 
    }
// ...
```

The key to the radio button success is that the control's style (`BS_RADIOBUTTON` or `BS_AUTORADIOBUTTON`) is caught in this `if` block, and the subsequent `SetWindowTheme` call (with the empty string parameter `L""`) effectively **removes the visual theme**, forcing the GDI drawing mode which respects the color set by your `OnCtlColor` function.

### 2\. The Missing Logic (Checkboxes)

The issue is that if the control style is **`BS_CHECKBOX`** or **`BS_AUTOCHECKBOX`**, it currently falls through this block and continues to use the default themed drawing, which forces the black text color.

To fix the black checkbox labels, you must include the checkbox styles in that same block of code to remove the theme.

-----

## 💡 The Minimal Fix: Modifying `DarkMode::AdjustControls`

You need to update the `if` condition in `DarkMode::AdjustControls` to explicitly include the two common checkbox styles:

#### Required Code Change

Locate this line in your `DarkMode::AdjustControls` function:

```cpp
// Original condition
if (style == BS_GROUPBOX || style == BS_RADIOBUTTON || style == BS_AUTORADIOBUTTON)
```

And update it to this, ensuring the checkbox styles are also included:

```cpp
// Corrected condition
if (style == BS_GROUPBOX || style == BS_RADIOBUTTON || style == BS_AUTORADIOBUTTON || 
    style == BS_CHECKBOX || style == BS_AUTOCHECKBOX) // <--- ADDED CHECKBOX STYLES
{
    // ... the SetWindowTheme(hWnd, ..., L"") call follows, which forces the color change
    SetWindowTheme(hWnd, _darkModeEnabled ? L"DarkMode_Explorer" : L"Explorer", L"");
}
```

By adding `BS_CHECKBOX` and `BS_AUTOCHECKBOX`, you ensure that checkboxes are also theme-disabled, which will force their labels to be drawn using GDI, allowing your existing `CTLCOLOR_STATIC` (or similar) logic in `OnCtlColor` to correctly paint the text label white.

-----

Would you like to confirm the exact lines in the `DarkMode::AdjustControls` function so you can apply this change?
