### PR TITLE
Fix Column Header Bar Drawing Glitch

### DIFF
--- a/windirstat/Controls/OwnerDrawnListControl.cpp
+++ b/windirstat/Controls/OwnerDrawnListControl.cpp
@@ -540,6 +540,7 @@ BEGIN_MESSAGE_MAP(COwnerDrawnListControl, CSortingListControl)
     ON_NOTIFY(HDN_ITEMCHANGING, 0, OnHdnItemchanging)
     ON_WM_SHOWWINDOW()
     ON_NOTIFY(NM_CUSTOMDRAW, 0, OnCustomDraw)
+    ON_WM_PAINT()
 END_MESSAGE_MAP()
 
 void COwnerDrawnListControl::OnCustomDraw(NMHDR* pNMHDR, LRESULT* pResult)
@@ -644,4 +645,15 @@ void COwnerDrawnListControl::OnHdnItemchanging(NMHDR* /*pNMHDR*/, LRESULT* pResu
     InvalidateRect(nullptr);
 
     *pResult = FALSE;
+}
+
+void COwnerDrawnListControl::OnPaint()
+{
+    CHeaderCtrl* pHeader = GetHeaderCtrl();
+    if (pHeader && pHeader->GetSafeHwnd())
+    {
+        pHeader->Invalidate(FALSE);
+        pHeader->UpdateWindow();
+    }
+    CSortingListControl::OnPaint();
 }

--- a/windirstat/Controls/OwnerDrawnListControl.h
+++ b/windirstat/Controls/OwnerDrawnListControl.h
@@ -121,4 +121,5 @@ protected:
     afx_msg void OnHdnDividerdblclick(NMHDR* pNMHDR, LRESULT* pResult);
     afx_msg void OnHdnItemchanging(NMHDR* pNMHDR, LRESULT* pResult);
     afx_msg void OnCustomDraw(NMHDR* pNMHDR, LRESULT* pResult);
+    afx_msg void OnPaint();
 };


### PR DESCRIPTION
- Fix Column Header Bar Drawing Glitch of the bar being white during a scan started with command-line without any modal in dark mode