### PR TITLE
Refactor CMessageBox to streamline calls

### DIFF
--- a/windirstat/Controls/FileDupeControl.cpp
+++ b/windirstat/Controls/FileDupeControl.cpp
@@ -43,11 +43,18 @@ void CFileDupeControl::ProcessDuplicate(CItem* item, BlockingQueue<CItem*>* queu
         m_showCloudWarningOnThisScan = false;
 
         // Show warning dialog
-        CMessageBoxDlg dlg(Localization::Lookup(IDS_DUPLICATES_WARNING), Localization::LookupNeutral(AFX_IDS_APP_TITLE),
-            MB_OK | MB_ICONINFORMATION, this, {}, Localization::Lookup(IDS_DONT_SHOW_AGAIN), false);
-        if (dlg.DoModal() == IDOK && dlg.IsCheckboxChecked())
+        if (COptions::SkipDupeDetectionCloudLinks && item->IsTypeOrFlag(ITRP_CLOUD) && m_showCloudWarningOnThisScan)
         {
-            COptions::ShowDupeDetectionCloudLinksWarning = false;
+            m_showCloudWarningOnThisScan = false;
+
+            // Show warning and immediately "unpack" the returned structure
+            if (const auto [nID, isChecked] = CMessageBoxDlg::Show(Localization::Lookup(IDS_DUPLICATES_WARNING),
+                Localization::Lookup(IDS_DONT_SHOW_AGAIN), false, MB_OK | MB_ICONINFORMATION, this);
+                nID == IDOK && isChecked)
+            {
+                COptions::ShowDupeDetectionCloudLinksWarning = false;
+            }
+            return;
         }
         return;
     }

--- a/windirstat/Dialogs/MessageBoxDlg.cpp
+++ b/windirstat/Dialogs/MessageBoxDlg.cpp
@@ -60,6 +60,18 @@ CMessageBoxDlg::CMessageBoxDlg(const std::wstring& message, const std::wstring& 
         iconIter->second : IDI_INFORMATION);
 }
 
+WdsMessageBoxResult CMessageBoxDlg::Show(const std::wstring& message, const std::vector<std::wstring>& listViewItems, const std::wstring& checkboxText, bool checkboxValue, UINT type, CWnd* pParent, const CSize& initialSize, const std::wstring& title)
+{
+    CWnd* parent = pParent ? pParent : AfxGetMainWnd();
+
+    CMessageBoxDlg dlg(message, title, type, parent, listViewItems, checkboxText, checkboxValue);
+
+    if (initialSize.cx > 0 || initialSize.cy > 0)
+        dlg.SetInitialWindowSize(initialSize);
+
+    return { static_cast<int>(dlg.DoModal()), dlg.IsCheckboxChecked() };
+}
+
 bool CMessageBoxDlg::IsCheckboxChecked() const
 {
     return m_checkboxChecked;

--- a/windirstat/Dialogs/MessageBoxDlg.h
+++ b/windirstat/Dialogs/MessageBoxDlg.h
@@ -20,6 +20,8 @@
 #include "pch.h"
 #include "Layout.h"
 
+struct WdsMessageBoxResult { int nID; bool isChecked; };
+
 //
 // CMessageBoxDlg. Custom message box dialog with dark mode support.
 // Emulates the functionality of MessageBox/AfxMessageBox.
@@ -31,6 +33,10 @@ class CMessageBoxDlg final : public CLayoutDialogEx
     CMessageBoxDlg(const std::wstring& message, const std::wstring& title, UINT type, CWnd* pParent = nullptr,
         const std::vector<std::wstring>& listViewItems = {}, const std::wstring& checkBoxText = {}, bool checkBoxValue = false);
     ~CMessageBoxDlg() override = default;
+
+    static int Show(const std::wstring& message, UINT type = MB_OK, CWnd* pParent = nullptr, const CSize& initialSize = {}, const std::wstring& title = Localization::LookupNeutral(AFX_IDS_APP_TITLE)) { return Show(message, {}, {}, false, type, pParent, initialSize, title).nID; }
+    static WdsMessageBoxResult Show(const std::wstring& message, const std::wstring& checkboxText, bool checkboxValue = false, UINT type = MB_YESNO | MB_ICONQUESTION, CWnd* pParent = nullptr, const CSize& initialSize = {}, const std::wstring& title = Localization::LookupNeutral(AFX_IDS_APP_TITLE)) { return Show(message, {}, checkboxText, checkboxValue, type, pParent, initialSize, title); }
+    static WdsMessageBoxResult Show(const std::wstring& message, const std::vector<std::wstring>& listViewItems, const std::wstring& checkboxText, bool checkboxValue = false, UINT type = MB_YESNO | MB_ICONWARNING, CWnd* pParent = nullptr, const CSize& initialSize = {}, const std::wstring& title = Localization::LookupNeutral(AFX_IDS_APP_TITLE));
 
     INT_PTR DoModal() override;
     void SetInitialWindowSize(const CSize size) { m_initialSize = size; }
@@ -56,7 +62,7 @@ protected:
     void ShiftControlsIfHidden(const CWnd* pTargetControl, const std::vector<CWnd*>& controlsToShift);
 
 private:
-
+    
     using ButtonContext = struct ButtonContext
     {
         BYTE btnLeftID = 0;

--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -446,24 +446,19 @@ void CDirStatDoc::DeletePhysicalItems(const std::vector<CItem*>& items, const bo
     {
         // Build list of file paths for the message box
         std::vector<std::wstring> filePaths;
-        for (const auto& item : items)
-        {
-            filePaths.push_back(item->GetPath());
-        }
+        for (const auto& item : items) filePaths.push_back(item->GetPath());
 
-        // Display the file deletion warning dialog
-        CMessageBoxDlg warning(
-            Localization::Lookup(emptyOnly ? IDS_EMPTY_FOLDER_WARNING : IDS_DELETE_WARNING),
-            Localization::Lookup(IDS_DELETE_TITLE),
-            MB_YESNO | MB_ICONWARNING, AfxGetMainWnd(), filePaths,
-            Localization::Lookup(IDS_DONT_SHOW_AGAIN), false);
+        // Display the file deletion warning dialog with custom width and height
+        if (![&]() -> bool {
+            const auto result = CMessageBoxDlg::Show(Localization::Lookup(emptyOnly ? IDS_EMPTY_FOLDER_WARNING : IDS_DELETE_WARNING), filePaths,
+                Localization::Lookup(IDS_DONT_SHOW_AGAIN), false, MB_YESNO | MB_ICONWARNING, AfxGetMainWnd(), { 600, 400 }, Localization::Lookup(IDS_DELETE_TITLE));
 
-        // Change default width and display
-        warning.SetInitialWindowSize({ 600, 400 });
-        if (IDYES != warning.DoModal()) return;
+            if (result.nID != IDYES) return false;
 
-        // Save off the deletion warning preference
-        COptions::ShowDeleteWarning = !warning.IsCheckboxChecked();
+            // Save off the deletion warning preference
+            COptions::ShowDeleteWarning = !result.isChecked;
+            return true;
+        }()) return;
     }
 
     // Clear active selections


### PR DESCRIPTION
- Introduced three Show() static overloads to streamline CMessageBoxDlg calls and mimic the calling style of MessageBox():
    - Standard: with additional optional parameter to control initial window size.
    - With Checkbox: with additional checkbox support for persistent options like "Don't show again."
    - File Delete Dialog: additionally accepts vector-based list data for displaying multiple paths
- Added struct WdsMessageBoxResult to allow returning both button IDs and checkbox states
- Optimized parameters arrangement and defaults to help shorten calls by internalizing common values like application titles and parent handles
- Refactored call sites using the IIFE pattern to improve code readability