### PR TITLE
Adjust dark mode grid color and add top-row boundary

### DIFF
--- a/windirstat/Controls/OwnerDrawnListControl.cpp
+++ b/windirstat/Controls/OwnerDrawnListControl.cpp
@@ -464,8 +464,16 @@ void COwnerDrawnListControl::DrawItem(LPDRAWITEMSTRUCT pdis)
         if (m_showGrid)
         {
             constexpr COLORREF gridColor = RGB(212, 208, 200);
-            CPen pen(PS_SOLID, 1, gridColor);
+            constexpr COLORREF gridColorDark = RGB(99, 99, 99);
+            CPen pen(PS_SOLID, 1, DarkMode::IsDarkModeActive() ? gridColorDark : gridColor);
             CSelectObject sopen(&dcMem, &pen);
+
+            // Draw top line for first item
+            if (pdis->itemID == 0)
+            {
+                dcMem.MoveTo(rcDraw.left, rcDraw.top);
+                dcMem.LineTo(rcDraw.right, rcDraw.top);
+            }
 
             dcMem.MoveTo(rcDraw.right - 1, rcDraw.top);
             dcMem.LineTo(rcDraw.right - 1, rcDraw.bottom);


### PR DESCRIPTION
Before
<img width="1675" height="925" alt="image" src="https://github.com/user-attachments/assets/cff50cc7-a17a-4c22-9b34-97128c80ffcd" />
<img width="1675" height="925" alt="image" src="https://github.com/user-attachments/assets/67ba1413-9d6c-4dcf-96d1-f742c13fe7ba" />

After
<img width="1675" height="925" alt="image" src="https://github.com/user-attachments/assets/1a7010e4-7426-4e68-af92-af9e06076bbf" />
<img width="1675" height="925" alt="image" src="https://github.com/user-attachments/assets/ac205f5f-33d2-45bb-95be-af14d3102f92" />
