### PR TITLE
Increase message box width for hash result

### DIFF
--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -1569,7 +1569,7 @@ void CDirStatDoc::OnComputeHash()
 
     // Display result in message box
     CMessageBoxDlg dlg(hashResult, Localization::LookupNeutral(AFX_IDS_APP_TITLE), MB_OK | MB_ICONINFORMATION);
-    dlg.SetInitialWindowSize(CSize(1000, 200));
+    dlg.SetInitialWindowSize(CSize(1110, 200));
     dlg.DoModal();
 }
 


### PR DESCRIPTION
Adjusted the initial window size of the message box displaying the hash result from 1000 to 1110 pixels wide to accommodate default font change in git commit 7be8c990aa469c4be7b4a8d4a3f535e45a9e446a

Before
<img width="986" height="238" alt="image" src="https://github.com/user-attachments/assets/fc979cc2-031e-4cb6-b912-19fba329278f" />

After
<img width="1096" height="238" alt="image" src="https://github.com/user-attachments/assets/288d0316-c6e6-4608-b25e-01385cf79da6" />
