### PR TITLE
Correct Non-Neutral Language Loading (refined) / Refactoring

### DIFF
--- a/windirstat/Constants.h
+++ b/windirstat/Constants.h
@@ -29,6 +29,8 @@ namespace wds
     inline constexpr auto strEmpty        = L"";
     inline constexpr auto chrBlankSpace   = L' ';
     inline constexpr auto chrStar         = L'*';
+    inline constexpr auto chrEqual        = L'=';
+    inline constexpr auto szNpos          = std::wstring::npos;
 
     inline constexpr auto strExplorerKey = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
     inline constexpr auto strThemesKey   = L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";

--- a/windirstat/windirstat.vcxproj
+++ b/windirstat/windirstat.vcxproj
@@ -721,7 +721,7 @@
     <Text Include="res\langs\lang_sv.txt" />
     <Text Include="res\langs\lang_tr.txt" />
     <Text Include="res\langs\lang_uk.txt" />
-    <Text Include="res\langs\lang_zh-hk.txt" />
+    <Text Include="res\langs\lang_zh-HK.txt" />
     <Text Include="res\langs\lang_zh.txt" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
- renamed lang_zh-hk.txt to lang_zh-HK.txt to ensure working with the localization engine
- fix issues that zh-HK and zh not loading the correct language
- change language code fallback order to BCP-47 first then ISO 639-1
- minor refactor to improve code readability and maintainability