### PR TITLE
Add silent mode for command-line execution

### DIFF
--- a/windirstat/Version.h
+++ b/windirstat/Version.h
@@ -35,7 +35,7 @@
 
 #define PRD_MAJVER                  2 // major product version
 #define PRD_MINVER                  5 // minor product version
-#define PRD_PATCH                   3 // patch number for product
+#define PRD_PATCH                   4 // patch number for product
 #define PRD_BUILD                   GIT_COUNT // build number for product
 #define FILE_MAJVER                 PRD_MAJVER // major file version
 #define FILE_MINVER                 PRD_MINVER // minor file version

--- a/windirstat/WinDirStat.cpp
+++ b/windirstat/WinDirStat.cpp
@@ -233,6 +233,7 @@ class CWinDirStatCommandLineInfo final : public CCommandLineInfo
     const std::wstring saveDupesToCSVFlag = L"savedupestocsv";
     const std::wstring loadFromCSVFlag = L"loadfromcsv";
     const std::wstring legacyUninstallFlag = L"legacyuninstall";
+    const std::wstring silentFlag = L"silent";
 
 public:
 
@@ -252,18 +253,32 @@ public:
             {
                 CDirStatApp::Get()->m_saveToCsvPath = param;
                 COptions::ScanForDuplicates = false;
+                m_pendingFlag.clear();
             }
             else if (m_pendingFlag == saveDupesToCSVFlag)
             {
                 CDirStatApp::Get()->m_saveDupesToCsvPath = param;
                 COptions::ScanForDuplicates = true;
+                m_pendingFlag.clear();
             }
             else if (m_pendingFlag == loadFromCSVFlag)
             {
                 CDirStatApp::Get()->m_loadFromCsvPath = param;
+                m_pendingFlag.clear();
             }
-            
-            m_pendingFlag.clear();
+            else if (m_pendingFlag == silentFlag)
+            {
+                if (m_strFileName.IsEmpty())
+                {
+                    m_strFileName = param.c_str();
+                }
+                else
+                {
+                    CDirStatApp::Get()->m_saveToCsvPath = param;
+                    COptions::ScanForDuplicates = false;
+                    m_pendingFlag.clear();
+                }
+            }
             return;
         }
 
@@ -282,7 +297,7 @@ public:
 
         // Handle flags
         param = MakeLower(param);
-        if (param == saveToCSVFlag || param == saveDupesToCSVFlag || param == loadFromCSVFlag)
+        if (param == saveToCSVFlag || param == saveDupesToCSVFlag || param == loadFromCSVFlag || param == silentFlag)
         {
             m_pendingFlag = param;
         }


### PR DESCRIPTION
This change introduces a silent mode for WinDirStat, allowing it to be run from the command line to scan a directory and save the results to a CSV file without displaying a graphical user interface.

**Purpose:**
- To enable automation and scripting of WinDirStat scans.
- To allow for generating directory analysis reports as part of automated processes or batch jobs.

**Usage:**
The new ``/silent`` command-line argument is used to trigger this mode. When running in silent mode, a path to scan and an output CSV file must be provided.

**Syntax:**
windirstat.exe /silent <directory_to_scan> <path_to_output.csv>

**Example:**
windirstat.exe /silent "C:\Program Files" "C:\reports\windirstat_report.csv"

This enhancement allows users to leverage WinDirStat's capabilities in a more flexible way, particularly for system administrators and power users who need to generate reports without manual intervention.

and changed the version number from 2.5.3 to 2.5.4 in Version.h