### PR TITLE
Restore ∑ symbol for sum of selected files physical size

### DIFF
--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -1258,7 +1258,7 @@ void CMainFrame::UpdatePaneText()
 
     // Update select physical size
     const CClientDC dc(this);
-    const auto sizeSummary = std::format(L"{}: {}", Localization::Lookup(IDS_COL_SIZE_PHYSICAL), FormatBytes(size));
+    const auto sizeSummary = std::format(L"{}: \u2211 {}", Localization::Lookup(IDS_COL_SIZE_PHYSICAL), FormatBytes(size));
     SetStatusPaneText(dc, ID_STATUSPANE_IDLE_INDEX, fileSelectionText);
     SetStatusPaneText(dc, ID_STATUSPANE_SIZE_INDEX, (size != MAXULONG64) ? sizeSummary : wds::strEmpty, 175);
     SetStatusPaneText(dc, ID_STATUSPANE_RAM_INDEX, CDirStatApp::GetCurrentProcessMemoryInfo(), 175);


### PR DESCRIPTION
This PR restore ∑ symbol for sum of selected files physical size to resolve #433 user confusion on the meaning of  `Physical Size: ` in the status bar.

Screenshot
<img width="623" height="45" alt="image" src="https://github.com/user-attachments/assets/56ddc412-1817-4857-b679-8bb35f4fd913" />
