### PR TITLE
Show Extension and Treemap views via splitter drag gesture

### DIFF
--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -166,7 +166,6 @@ void CWdsSplitterWnd::StopTracking(const BOOL bAccept)
 
     if (bAccept)
     {
-        CMainFrame* pMainFrame = CMainFrame::Get();
         CRect rcClient;
         GetClientRect(rcClient);
 
@@ -177,12 +176,11 @@ void CWdsSplitterWnd::StopTracking(const BOOL bAccept)
             GetColumnInfo(0, cxLeft, dummy);
 
             if (rcClient.Width() > 0)
-            {
-                CExtensionView* pExtensionView = pMainFrame->GetExtensionView();
-
+            {        
                 // if user drag the splitter to show the extension view,
                 // treat that as an intent to enable showing file types in the extension view
-                if (pExtensionView != nullptr && !pExtensionView->IsShowTypes()) 
+                if (CExtensionView* pExtensionView = CMainFrame::Get()->GetExtensionView();
+                    pExtensionView != nullptr && !pExtensionView->IsShowTypes()) 
                 {
                     pExtensionView->ShowTypes(true);
                 }
@@ -198,11 +196,10 @@ void CWdsSplitterWnd::StopTracking(const BOOL bAccept)
 
             if (rcClient.Height() > 0)
             {
-                CTreeMapView* pTreeMapView = pMainFrame->GetTreeMapView();
-
                 // if user drag the splitter to show the treemap view,
                 // treat that as an intent to enable treemap
-                if (pTreeMapView != nullptr && !pTreeMapView->IsShowTreeMap())
+                if (CTreeMapView* pTreeMapView = CMainFrame::Get()->GetTreeMapView();
+                    pTreeMapView != nullptr && !pTreeMapView->IsShowTreeMap())
                 {
                     pTreeMapView->ShowTreeMap(true);
                 }


### PR DESCRIPTION
This is used to be a UI bug which the user can drag the frame splitter from the top edge and the right edge of the window to unhide the `File Type` and `Treemap`, but it would ended up with a empty view, this fix transform this bug into a UX genture feature to show these two views.


Before

<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/71c8550c-4247-4fe7-88d9-d2698e468410" />

After

<img width="1920" height="1050" alt="image" src="https://github.com/user-attachments/assets/4e9a16dd-d6d6-47b5-9895-f41ac59b56ae" />

