### PR TITLE
Add Sticky Drive Selection to Drives Lists

### DIFF
--- a/windirstat/Dialogs/SelectDrivesDlg.cpp
+++ b/windirstat/Dialogs/SelectDrivesDlg.cpp
@@ -283,9 +283,29 @@ void CDrivesList::OnDoubleClick(NMHDR* /*pNMHDR*/, LRESULT* pResult)
     (void) GetParent()->SendMessage(WMU_OK);
 }
 
+void CDrivesList::OnLButtonDown(UINT nFlags, CPoint point)
+{
+    LVHITTESTINFO lvhti = { 0 };
+    lvhti.pt = point;
+
+    if (SubItemHitTest(&lvhti) != -1)
+    {
+        int nItem = lvhti.iItem;
+        UINT uState = GetItemState(nItem, LVIS_SELECTED);
+        SetItemState(nItem, (uState & LVIS_SELECTED) ? 0 : (LVIS_SELECTED | LVIS_FOCUSED),
+            LVIS_SELECTED | LVIS_FOCUSED);
+        SetFocus();
+    }
+    else
+    {
+        CWdsListControl::OnLButtonDown(nFlags, point);
+    }
+}
+
 BEGIN_MESSAGE_MAP(CDrivesList, CWdsListControl)
     ON_NOTIFY_REFLECT(LVN_DELETEITEM, OnLvnDeleteItem)
     ON_NOTIFY_REFLECT(NM_DBLCLK, OnDoubleClick)
+    ON_WM_LBUTTONDOWN()
 END_MESSAGE_MAP()
 
 void CDrivesList::OnLvnDeleteItem(NMHDR* pNMHDR, LRESULT* pResult)
@@ -373,7 +393,7 @@ BOOL CSelectDrivesDlg::OnInitDialog()
     m_driveList.ShowGrid(COptions::ListGrid);
     m_driveList.ShowStripes(COptions::ListStripes);
     m_driveList.ShowFullRowSelection(COptions::ListFullRowSelection);
-    m_driveList.SetExtendedStyle(m_driveList.GetExtendedStyle() | LVS_EX_HEADERDRAGDROP);
+    m_driveList.SetExtendedStyle(m_driveList.GetExtendedStyle() | LVS_EX_HEADERDRAGDROP | LVS_EX_FULLROWSELECT);
 
     m_driveList.InsertColumn(CHAR_MAX, Localization::Lookup(IDS_COL_NAME).c_str(), LVCFMT_LEFT, DpiRest(150), COL_DRIVES_NAME);
     m_driveList.InsertColumn(CHAR_MAX, Localization::Lookup(IDS_COL_TOTAL).c_str(), LVCFMT_RIGHT, DpiRest(65), COL_DRIVES_TOTAL);

--- a/windirstat/Dialogs/SelectDrivesDlg.h
+++ b/windirstat/Dialogs/SelectDrivesDlg.h
@@ -95,6 +95,7 @@ class CDrivesList final : public CWdsListControl
     DECLARE_MESSAGE_MAP()
     afx_msg void OnLvnDeleteItem(NMHDR* pNMHDR, LRESULT* pResult);
     afx_msg void OnDoubleClick(NMHDR* pNMHDR, LRESULT* pResult);
+    afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 };
 
 //


### PR DESCRIPTION
- allow user to toggle select individual drive on the drives list by single click each drive for mouse only control
- expend the hitbox for drag selection box to whole row on the drives list

Showcase animation
<img width="1662" height="1112" alt="Showcase" src="https://github.com/user-attachments/assets/18e4d914-2e39-4651-b7e0-672788b37e11" />
Credit: Animated PNG recorded with [ScreenToGif](https://github.com/NickeManarin/ScreenToGif)
