### PR TITLE
Fix Extension Column Auto-size Bug Revision

### DIFF
--- a/windirstat/Controls/DrawTextCache.cpp
+++ b/windirstat/Controls/DrawTextCache.cpp
@@ -22,7 +22,13 @@ DrawTextCache DrawTextCache::s_instance;
 
 void DrawTextCache::DrawTextCached(CDC* pDC, const std::wstring& text, CRect& rect, const bool leftAlign, const bool calcRect)
 {
-    if (!pDC || text.empty()) return;
+    // If no DC or empty text, collapse rect and return
+    if (!pDC || text.empty())
+    {
+        rect.right = rect.left;
+        rect.bottom = rect.top;
+        return;
+    }
 
     const UINT format = DT_SINGLELINE | DT_VCENTER | DT_WORD_ELLIPSIS | DT_NOPREFIX |
         (leftAlign ? DT_LEFT : DT_RIGHT) | (calcRect ? DT_CALCRECT : 0);

--- a/windirstat/Controls/WdsListControl.cpp
+++ b/windirstat/Controls/WdsListControl.cpp
@@ -125,15 +125,7 @@ void CWdsListItem::DrawLabel(const CWdsListControl* list, CDC* pdc, CRect& rc, c
     rcRest.DeflateRect(list->GetTextXMargin(), 0);
 
     CRect rcLabel = rcRest;
-
-    if (GetText(0).empty())
-    {
-        rcLabel.right = rcLabel.left;
-    }
-    else
-    {
-        DrawTextCache::Get()->DrawTextCached(pdc, GetText(0), rcLabel, true, true);
-    }
+    DrawTextCache::Get()->DrawTextCached(pdc, GetText(0), rcLabel, true, true);
 
     rcLabel.InflateRect(LABEL_INFLATE_CX, 0);
     rcLabel.top = rcRest.top + LABEL_Y_MARGIN;


### PR DESCRIPTION
Shift the fix even deeper to the source of the problem, which is cause by DrawTextCache::DrawTextCached aggressive return and done noting to the rect.