### PR TITLE
Add smart Extension and Treemap Show/Hide gesture

### DIFF
--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -161,51 +161,42 @@ END_MESSAGE_MAP()
 
 void CWdsSplitterWnd::StopTracking(const BOOL bAccept)
 {
+    // Define toggle functions for both views, which will show or hide the corresponding views based on the calculated visibility.
+    static constexpr bool (*toggleTreeMap)(bool) = [](bool isVisible) { CTreeMapView* pView = CMainFrame::Get()->GetTreeMapView(); return pView && (pView->ShowTreeMap(isVisible), true); };
+    static constexpr bool (*toggleExtension)(bool) = [](bool isVisible) { CExtensionView* pView = CMainFrame::Get()->GetExtensionView(); return pView && (pView->ShowTypes(isVisible), true); };
+
+    static constexpr struct {
+        void (CMainFrame::* minimize)();
+        int (CRect::* totalSize)() const;
+        bool (*toggle)(bool);
+    } views[] = {
+        { &CMainFrame::MinimizeTreeMapView,  &CRect::Height, toggleTreeMap },  // [0] TreeMap
+        { &CMainFrame::MinimizeExtensionView, &CRect::Width, toggleExtension } // [1] Extension List
+    };
+
     CSplitterWndEx::StopTracking(bAccept);
+    if (!bAccept) return;
 
-    if (bAccept)
+    int currentPos, dummy;
+    const bool isVertical = (GetColumnCount() > 1); // Determine if the splitter is vertical (columns) or horizontal (rows)
+    isVertical ? GetColumnInfo(0, currentPos, dummy) : GetRowInfo(0, currentPos, dummy); // Get the current position of the splitter
+    const auto& view = views[isVertical]; // Select view based on the splitter orientation
+    const CRect rcClient = ClientRectOf(this); // Get the current client area to calculate the total size for visibility determination
+    const int totalSize = (rcClient.*view.totalSize)(); // Calculate the left or upper view size
+    const bool isVisible = (totalSize - currentPos) > DpiRest(COptions::MinimizeViewThreshold); // Consider the view visible if larger than 10 pixels by default
+
+    if (totalSize <= 0) return;
+    if (!view.toggle(isVisible)) return; // Toggle Show/Hide of the view based on the calculated visibility
+
+    if (!isVisible)
     {
-        const CRect rcClient = ClientRectOf(this);
-        if (GetColumnCount() > 1)
-        {
-            int dummy;
-            int cxLeft;
-            GetColumnInfo(0, cxLeft, dummy);
-
-            if (rcClient.Width() > 0)
-            {        
-                // if user drag the splitter to show the extension view,
-                // treat that as an intent to enable showing file types in the extension view
-                if (CExtensionView* pExtensionView = CMainFrame::Get()->GetExtensionView();
-                    pExtensionView != nullptr && !pExtensionView->IsShowTypes()) 
-                {
-                    pExtensionView->ShowTypes(true);
-                }
-
-                m_splitterPos = static_cast<double>(cxLeft) / rcClient.Width();
-            }
-        }
-        else
-        {
-            int dummy;
-            int cyUpper;
-            GetRowInfo(0, cyUpper, dummy);
-
-            if (rcClient.Height() > 0)
-            {
-                // if user drag the splitter to show the treemap view,
-                // treat that as an intent to enable treemap
-                if (CTreeMapView* pTreeMapView = CMainFrame::Get()->GetTreeMapView();
-                    pTreeMapView != nullptr && !pTreeMapView->IsShowTreeMap())
-                {
-                    pTreeMapView->ShowTreeMap(true);
-                }
-                m_splitterPos = static_cast<double>(cyUpper) / rcClient.Height();
-            }
-        }
-        m_wasTrackedByUser = true;
-        *m_userSplitterPos = m_splitterPos;
+        (CMainFrame::Get()->*view.minimize)(); // Minimize the view if it considered not visible
+        return; // Early exit to keep the current splitter position unchanged for show views to function properly
     }
+
+    m_splitterPos = static_cast<double>(currentPos) / totalSize;
+    m_wasTrackedByUser = true;
+    *m_userSplitterPos = m_splitterPos;
 }
 
 void CWdsSplitterWnd::SetSplitterPos(const double pos)

--- a/windirstat/Options.cpp
+++ b/windirstat/Options.cpp
@@ -95,6 +95,7 @@ Setting<int> COptions::ConfigPage(OptionsGeneral, L"ConfigPage", 0);
 Setting<int> COptions::DarkMode(OptionsGeneral, L"DarkMode", DM_USE_WINDOWS, DM_DISABLED, DM_USE_WINDOWS);
 Setting<int> COptions::LanguageId(OptionsGeneral, L"LanguageId", 0);
 Setting<int> COptions::LargeFileCount(OptionsGeneral, L"LargeFileCount", 50, 0, 10000);
+Setting<int> COptions::MinimizeViewThreshold(OptionsGeneral, L"MinimizeViewThreshold", 10, 1, 10000);
 Setting<int> COptions::ScanningThreads(OptionsGeneral, L"ScanningThreads", 4, 1, 16);
 Setting<int> COptions::SelectDrivesRadio(OptionsDriveSelect, L"SelectDrivesRadio", 0, 0, 2);
 Setting<int> COptions::FileTreeColorCount(OptionsFileTree, L"FileTreeColorCount", 8);

--- a/windirstat/Options.h
+++ b/windirstat/Options.h
@@ -179,6 +179,7 @@ public:
     static Setting<int> FollowReparsePointMask;
     static Setting<int> LanguageId;
     static Setting<int> LargeFileCount;
+    static Setting<int> MinimizeViewThreshold;
     static Setting<int> ScanningThreads;
     static Setting<int> SelectDrivesRadio;
     static Setting<int> FileTreeColorCount;


### PR DESCRIPTION
- Drag splitter from the edge to show views
- Drag splitter to the edge to hide views
- Preserve user custom splitter positions when hiding views with dragging splitter to the edge, for menu/keyboard shortcut to function properly
- Add hidden setting MinimizeViewThreshold
- Refactored with Data-Driven Pattern

This is the follow-up refinement of #439