### PR TITLE
Fix dangling pointer from temporary wstring in "This PC" name lookup fallback

### DIFF
--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -132,7 +132,7 @@ BOOL CDirStatDoc::OnOpenDocument(LPCWSTR lpszPathName)
             ASSERT(FALSE);
         }
 
-        const LPCWSTR name = ppszName != nullptr ? const_cast<LPCWSTR>(*ppszName) : Localization::Lookup(IDS_THISPC).c_str();
+        const std::wstring name = ppszName != nullptr ? *ppszName : Localization::Lookup(IDS_THISPC);
         m_rootItem = new CItem(IT_MYCOMPUTER | ITF_ROOTITEM, name);
         for (const auto& rootFolder : selections)
         {


### PR DESCRIPTION
When trying to get the root computer object using `GetDisplayName` fails, there is a fallback using `Localization::Lookup(IDS_THISPC)`, but this calls `c_str` on a temporary `wstring` and stores the result in a variable before calling the `CItem` constructor on the next line, when the `wstring` has been automatically deleted, causing undefined behavior.

Since the `CItem` constructor takes a `const wstring` reference, not a pointer, this can be fixed by not calling `c_str` at all; `name` can be a `wstring` instead of a `LPCWSTR`. The old code was using the implicit `wstring` constructor from `LPWSTR` when constructing `CItem` with `LCPWSTR` argument.

The new code will convert `ppszName` to a `wstring` if it's not `nullptr`, but this would happen anyways by the implicit conversion.

The bug can be reproduced by replacing `FAILED(psi->GetDisplayName(SIGDN_NORMALDISPLAY, &ppszName))` with `true` to simulate a `GetDisplayName` failure. On a debug build, this would cause an assertion failure, but a release build would silently try to use the `Lookup` fallback, and end up with a dangling pointer. You need at least two drives to trigger this bug, since with only one the root object will be the drive instead of "This PC".

On my machine, this causes the root object to have a blank name.

Without fix:
<img width="2208" height="549" alt="image" src="https://github.com/user-attachments/assets/8326ba70-0785-4aea-81f2-25c6e34e342c" />


With fix:
<img width="1872" height="584" alt="image" src="https://github.com/user-attachments/assets/0cf3f94b-0d6b-45dc-8cd9-3768a72ce9b4" />
