### PR TITLE
Add FileTreeView hotkey for select and scroll folder or file to top

### DIFF
--- a/windirstat/Controls/FileTreeControl.cpp
+++ b/windirstat/Controls/FileTreeControl.cpp
@@ -28,12 +28,62 @@ bool CFileTreeControl::GetAscendingDefault(const int column)
     return column == COL_NAME || column == COL_LAST_CHANGE;
 }
 
+// Scroll to the first item of the same parent as the first selected item that matches any of the specified ITEMTYPE
+void CFileTreeControl::ScrollToFirstItemByType(ITEMTYPE itemType)
+{
+    CItem* const itemSelected = GetFirstSelectedItem<CItem>();
+    if (!itemSelected) return;
+
+    const CSetRedrawLock lock(this); // Supress redraw until the end of the function
+    CItem* const itemTarget = static_cast<CItem*>(itemSelected->GetParent());
+    CItem** const items = (CItem**)m_items.data();
+
+    for (int i : std::views::iota(0, static_cast<int>(m_items.size())))
+    {
+        CItem* const itemCurrent = items[i];
+
+        if (itemCurrent->GetParent() == itemTarget && itemCurrent->IsTypeOrFlag(itemType))
+        {
+            SetItemState(-1, 0, LVIS_SELECTED);
+            SetItemState(i, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+
+            if (CRect rect; GetItemRect(i, &rect, LVIR_BOUNDS))
+            {
+                Scroll(CSize(0, (i - GetTopIndex()) * rect.Height()));
+            }
+
+            return;
+        }
+    }
+}
+
 BEGIN_MESSAGE_MAP(CFileTreeControl, CTreeListControl)
+    ON_WM_KEYDOWN()
     ON_WM_LBUTTONDOWN()
     ON_WM_SETCURSOR()
 END_MESSAGE_MAP()
 
 CFileTreeControl* CFileTreeControl::m_singleton = nullptr;
+
+void CFileTreeControl::OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags)
+{
+    if (IsControlKeyDown())
+    {
+        if (nChar == VK_LEFT)
+        {
+            ScrollToFirstItemByType(IT_DIRECTORY);
+            return;
+        }
+
+        if (nChar == VK_RIGHT)
+        {
+            ScrollToFirstItemByType(IT_FILE);
+            return;
+        }
+    }
+
+    CTreeListControl::OnKeyDown(nChar, nRepCnt, nFlags);
+}
 
 void CFileTreeControl::OnLButtonDown(const UINT nFlags, const CPoint point)
 {

--- a/windirstat/Controls/FileTreeControl.h
+++ b/windirstat/Controls/FileTreeControl.h
@@ -29,9 +29,11 @@ public:
 
 protected:
 
+    void ScrollToFirstItemByType(ITEMTYPE itemType);
     static CFileTreeControl * m_singleton;
 
     DECLARE_MESSAGE_MAP()
+    afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
     afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
     afx_msg BOOL OnSetCursor(CWnd* pWnd, UINT nHitTest, UINT message);
 };


### PR DESCRIPTION
- Ctrl+Left for the first folder
- Ctrl+Right for the first file
- related to PR #477 and FR #476

---

## User Requirement

> @harryytm , I've started using the test build you provided for all my uses of WinDirStat; and I've found that the "Group Folders Before Files" option actually groups the folders _after_ the files when sorting by last change (with most recent changes first). So when trying to examine the most recently changed folders,it's necessary to scroll past all the files first, after each refresh.
> 
> Is it possible to group the folders before files in all cases when "group folders before files" is selected?
> 
> [edit: clarify sorting with "most recent changes first"] 

 _Originally posted by @codingatty in [#476](https://github.com/windirstat/windirstat/issues/476#issuecomment-4224841290)_