### PR TITLE
Configurable Subtree Percentage Indent

### DIFF
--- a/windirstat/Item.Extended.cpp
+++ b/windirstat/Item.Extended.cpp
@@ -64,7 +64,7 @@ bool CItem::DrawSubItem(const int subitem, CDC* pdc, CRect rc, const UINT state,
     else
     {
         rc.DeflateRect(2, 5);
-        rc.left += GetIndent() * rc.Width() / 10;
+        rc.left += GetIndent() * DpiRest(COptions::SubtreePercentageIndent);
 
         DrawPercentage(pdc, rc, GetFraction(), GetPercentageColor());
     }

--- a/windirstat/Options.cpp
+++ b/windirstat/Options.cpp
@@ -99,6 +99,7 @@ Setting<int> COptions::LargeFileCount(OptionsGeneral, L"LargeFileCount", 50, 0, 
 Setting<int> COptions::MinimizeViewThreshold(OptionsGeneral, L"MinimizeViewThreshold", 10, 1, 10000);
 Setting<int> COptions::ScanningThreads(OptionsGeneral, L"ScanningThreads", 4, 1, 16);
 Setting<int> COptions::SelectDrivesRadio(OptionsDriveSelect, L"SelectDrivesRadio", 0, 0, 2);
+Setting<int> COptions::SubtreePercentageIndent(OptionsFileTree, L"SubtreePercentageIndent", 16, 0, 1000);
 Setting<int> COptions::FileTreeColorCount(OptionsFileTree, L"FileTreeColorCount", 8);
 Setting<int> COptions::FilteringSizeMinimum(OptionsGeneral, L"FilteringSizeMinimum", 0);
 Setting<int> COptions::FilteringSizeUnits(OptionsGeneral, L"FilteringSizeUnits", 0);

--- a/windirstat/Options.h
+++ b/windirstat/Options.h
@@ -183,6 +183,7 @@ public:
     static Setting<int> MinimizeViewThreshold;
     static Setting<int> ScanningThreads;
     static Setting<int> SelectDrivesRadio;
+    static Setting<int> SubtreePercentageIndent;
     static Setting<int> FileTreeColorCount;
     static Setting<int> FilteringSizeMinimum;
     static Setting<int> FilteringSizeUnits;


### PR DESCRIPTION
- Configurable Subtree Percentage Indent, range 0 - 1000, Default 16, DPI aware
- Change indent logic to static width to improve UX

<img width="652" height="338" alt="image" src="https://github.com/user-attachments/assets/446cd42c-7c88-43e5-95a6-d91490736821" />
