### PR TITLE
Minor Number Formatting Fixes

### DIFF
--- a/windirstat/HelpersInterface.cpp
+++ b/windirstat/HelpersInterface.cpp
@@ -133,11 +133,13 @@ std::wstring FormatCount(const ULONGLONG n) noexcept
 std::wstring FormatDouble(const double d) noexcept
 {
     ASSERT(d >= 0);
+    const std::wstring s = { GetLocaleDecimalSeparator(), L'0', L'0' };
+    if (d < 0.005) return L"0" + s;
     const int x = std::lround(d * 100);
     const int i = x / 100;
     const int r = x % 100;
 
-    if (r == 0) return std::to_wstring(i);
+    if (r == 0) return std::to_wstring(i) + s;
     return std::to_wstring(i) + GetLocaleDecimalSeparator() +
         std::wstring({ static_cast<wchar_t>(L'0' + r / 10), static_cast<wchar_t>(L'0' + r % 10) });
 }

--- a/windirstat/Item.Extended.cpp
+++ b/windirstat/Item.Extended.cpp
@@ -598,10 +598,10 @@ void CItem::UpdateFreeSpaceItem()
         auto [total, free] = CDirStatApp::GetFreeDiskSpace(GetPath());
 
         // Recreate name based on updated free space and percentage
-        SetName(std::format(L"{:.2}|{} - {} ({:.1f}%)", GetNameView(),
+        SetName(std::format(L"{:.2}|{} - {} ({}%)", GetNameView(),
             FormatVolumeNameOfRootPath(GetPath()), Localization::Format(
                 IDS_DRIVE_ITEM_FREEsTOTALs, FormatBytes(free), FormatBytes(total)),
-            100.0 * free / total));
+            FormatDouble(100.0 * free / total)));
 
         // Update freespace item if it exists
         if (CItem* freeSpaceItem = FindFreeSpaceItem(); freeSpaceItem != nullptr)


### PR DESCRIPTION
- Change usage percentage in volume name to use FormatDouble()
- ~~Add padding 00 to decimal places to form 123.00 or 0.00 instead of 123 or 0 to make the numbers look uniform in the column~~
- ~~Skip integer calculations that would resulted in 0.00~~

<img width="378" height="33" alt="image" src="https://github.com/user-attachments/assets/b5b0c223-63d0-459c-ba47-eb3a7423da92" />

---

<img width="267" height="83" alt="image" src="https://github.com/user-attachments/assets/2ad427d6-6a2c-44cc-aa0e-22fd6dccb34c" />
