### PR TITLE
Change configuration icon to a Wrench

### DIFF
--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -1381,7 +1381,7 @@ void CMainFrame::RebuildToolBar()
             { ID_SCAN_SUSPEND,            [](int s) { return Icons::Make<Icons::FromCharacter<L'⏸', RGB(200, 160,   0)>>(s); } },
             { ID_REFRESH_ALL,             [](int s) { return Icons::Make<Icons::FromCharacter<L'↻',  RGB(  0, 156, 221)>>(s); } },
             { ID_SEARCH,                  [](int s) { return Icons::Make<Icons::FromCharacter<L'⌕',  RGB(140, 140, 140)>>(s); } },
-            { ID_CONFIGURE,               [](int s) { return Icons::Make<Icons::FromCharacter<L'⚙', RGB(140, 140, 140)>>(s); } },
+            { ID_CONFIGURE,               [](int s) { return Icons::Make<Icons::FromCharacter<L'', RGB(140, 140, 140)>>(s); } },
             { ID_HELP_MANUAL,             [](int s) { return Icons::Make<Icons::FromCharacter<L'❔', RGB(100, 149, 237)>>(s); } },
             { ID_CLEANUP_PROPERTIES,      [](int s) { return Icons::Make<Icons::PaintProperties>(s); }      },
             { ID_FILE_SELECT,             [](int s) { return Icons::Make<Icons::PaintFileSelect>(s); }       },


### PR DESCRIPTION
@NoMoreFood After digging through Windows Character Map in Segoe UI Symbol, I found Wrench symbol  (L'\xE15E'), which is a far more superior choice than thick gear symbol  (L'xE115') and ⚒(L'x26CF'), due it is instantly understood by user that is for configuration(which is very important) and looks clean, it also works with existing `FromCharacter` without changing its code.
<img width="555" height="624" alt="image" src="https://github.com/user-attachments/assets/d7fb6d33-63bb-430b-8763-720b3de0a307" />

Render as follows on the toolbar

Small
<img width="134" height="81" alt="image" src="https://github.com/user-attachments/assets/0dafd6f9-7a7c-447d-9608-b34f135f7d42" />

Large
<img width="152" height="93" alt="image" src="https://github.com/user-attachments/assets/25d29153-7eba-4193-801b-1f62fca15508" />

