### PR TITLE
Restore ScrollToFirstItemByType

### DIFF
--- a/windirstat/Controls/FileTreeControl.cpp
+++ b/windirstat/Controls/FileTreeControl.cpp
@@ -28,8 +28,8 @@ bool CFileTreeControl::GetAscendingDefault(const int column)
     return column == COL_NAME || column == COL_LAST_CHANGE;
 }
 
-// Select the first item of the same parent as the first selected item that matches any of the specified ITEMTYPE
-void CFileTreeControl::SelectFirstItemByType(ITEMTYPE itemType)
+// Scroll to the first item of the same parent as the first selected item that matches any of the specified ITEMTYPE
+void CFileTreeControl::ScrollToFirstItemByType(ITEMTYPE itemType)
 {
     CItem* const itemSelected = GetFirstSelectedItem<CItem>();
     if (!itemSelected) return;
@@ -46,6 +46,12 @@ void CFileTreeControl::SelectFirstItemByType(ITEMTYPE itemType)
         {
             SetItemState(-1, 0, LVIS_SELECTED);
             SetItemState(i, LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+
+            if (CRect rect; GetItemRect(i, &rect, LVIR_BOUNDS))
+            {
+                Scroll(CSize(0, (i - GetTopIndex()) * rect.Height()));
+            }
+
             return;
         }
     }
@@ -65,13 +71,13 @@ void CFileTreeControl::OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags)
     {
         if (nChar == VK_LEFT)
         {
-            SelectFirstItemByType(IT_DIRECTORY);
+            ScrollToFirstItemByType(IT_DIRECTORY);
             return;
         }
 
         if (nChar == VK_RIGHT)
         {
-            SelectFirstItemByType(IT_FILE);
+            ScrollToFirstItemByType(IT_FILE);
             return;
         }
     }

--- a/windirstat/Controls/FileTreeControl.h
+++ b/windirstat/Controls/FileTreeControl.h
@@ -29,7 +29,7 @@ public:
 
 protected:
 
-    void SelectFirstItemByType(ITEMTYPE itemType);
+    void ScrollToFirstItemByType(ITEMTYPE itemType);
     static CFileTreeControl * m_singleton;
 
     DECLARE_MESSAGE_MAP()


### PR DESCRIPTION
Scroll to behavior is the key feature and intention of ScrollToFirstItemByType and not a bug.

Original user requirement in #476

> [@harryytm](https://github.com/harryytm) , I've started using the test build you provided for all my uses of WinDirStat; and I've found that the "Group Folders Before Files" option actually groups the folders _after_ the files when sorting by last change (with most recent changes first). So when trying to examine the most recently changed folders,it's necessary to scroll past all the files first, after each refresh.
> 
> Is it possible to group the folders before files in all cases when "group folders before files" is selected?
> 
> [edit: clarify sorting with "most recent changes first"]

> > So when trying to examine the most recently changed folders,it's necessary to scroll past all the files first, after each refresh.
> 
> I am using Gemini to prototype a feature that scroll programmatically via a hotkey at the moment, it would select the first folder and scroll it to the top of the viewport as possible, might be that is what you want, this function don't need too much radical architectural changes to WDS, which might be easier to be merge into the main branch. You know I don't have the admin right of the repo, [@NoMoreFood](https://github.com/NoMoreFood) do.

