### PR TITLE
Resize Pause Icon To Match Size

### DIFF
--- a/windirstat/Controls/IconHandler.cpp
+++ b/windirstat/Controls/IconHandler.cpp
@@ -309,8 +309,8 @@ namespace Icons
     void PaintPause(Graphics& g)
     {
         SolidBrush amberBrush(C(200, 160, 0));
-        g.FillRectangle(&amberBrush, 16, 12, 12, 40);
-        g.FillRectangle(&amberBrush, 36, 12, 12, 40);
+        g.FillRectangle(&amberBrush, 5, 5, 19, 54);
+        g.FillRectangle(&amberBrush, 39, 5, 19, 54);
     }
 
     void PaintMagnifier(Graphics& g, bool plus)


### PR DESCRIPTION
<img width="405" height="46" alt="image" src="https://github.com/user-attachments/assets/e3fe1b7e-4804-4a63-8af7-af22e4c933a5" />

Windows 7

<img width="329" height="34" alt="image" src="https://github.com/user-attachments/assets/bacdb248-3988-4035-afcc-27c1c5c6034b" />

Before

<img width="407" height="45" alt="image" src="https://github.com/user-attachments/assets/f6efab75-1cbd-4039-aa96-588d57d9b339" />

Just me being OCD, I am so sorry XD.