### PR TITLE
Force Enable TreeMap on Zoom In/Out

### DIFF
--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -1300,6 +1300,8 @@ void CDirStatDoc::OnTreeMapZoomIn()
     {
         SetZoomItem(item->IsRootItem() ? GetRootItem() :
             item->IsTypeOrFlag(IT_FILE) ? item->GetParent() : item);
+        if (!CMainFrame::Get()->GetTreeMapView()->IsShowTreeMap())
+            CMainFrame::Get()->RestoreTreeMapView(true);
     }
 }
 
@@ -1308,6 +1310,8 @@ void CDirStatDoc::OnTreeMapZoomOut()
     if (GetZoomItem() != nullptr)
     {
         SetZoomItem(GetZoomItem()->GetParent());
+        if (!CMainFrame::Get()->GetTreeMapView()->IsShowTreeMap())
+            CMainFrame::Get()->RestoreTreeMapView(true);
     }
 }
 

--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -780,8 +780,9 @@ void CMainFrame::MinimizeTreeMapView()
     m_splitter.SetSplitterPos(1.0);
 }
 
-void CMainFrame::RestoreTreeMapView()
+void CMainFrame::RestoreTreeMapView(bool force)
 {
+    if (force) GetTreeMapView()->ShowTreeMap(true);
     if (GetTreeMapView()->IsShowTreeMap())
     {
         m_splitter.RestoreSplitterPos(0.5);

--- a/windirstat/MainFrame.h
+++ b/windirstat/MainFrame.h
@@ -148,7 +148,7 @@ protected:
     void InitialShowWindow();
     void InvokeInMessageThread(std::function<void()> callback) const;
 
-    void RestoreTreeMapView();
+    void RestoreTreeMapView(bool forced = false);
     void RestoreExtensionView();
     void MinimizeTreeMapView();
     void MinimizeExtensionView();


### PR DESCRIPTION
Address user confusions of Zoom In/Out do noting with TreeMap is hidden.