### PR TITLE
Address TreeMap Ensure Visible Regression

### DIFF
--- a/windirstat/Controls/TreeListControl.cpp
+++ b/windirstat/Controls/TreeListControl.cpp
@@ -255,7 +255,7 @@ bool CTreeListControl::IsItemSelected(const CTreeListItem* item) const
     return false;
 }
 
-void CTreeListControl::SelectItem(const CTreeListItem* item, const bool deselect, const bool focus)
+void CTreeListControl::SelectItem(const CTreeListItem* item, const bool deselect, const bool focus, const bool scroll)
 {
     const int itempos = FindTreeItem(item);
     if (itempos == -1) return;
@@ -264,6 +264,7 @@ void CTreeListControl::SelectItem(const CTreeListItem* item, const bool deselect
     SetItemState(itempos, LVIS_SELECTED, LVIS_SELECTED);
     if (focus) SetItemState(itempos, LVIS_FOCUSED, LVIS_FOCUSED);
     if (focus) SetSelectionMark(itempos);
+    if (scroll) EnsureItemVisible(GetItem(itempos));
 }
 
 void CTreeListControl::SetRootItem(CTreeListItem* root)

--- a/windirstat/Controls/TreeListControl.h
+++ b/windirstat/Controls/TreeListControl.h
@@ -110,7 +110,7 @@ class CTreeListControl : public CWdsListControl
     void OnRemovingAllChildren(const CTreeListItem* parent);
     CTreeListItem* GetItem(int i) const;
     bool IsItemSelected(const CTreeListItem* item) const;
-    void SelectItem(const CTreeListItem* item, bool deselect = false, bool focus = false);
+    void SelectItem(const CTreeListItem* item, bool deselect = false, bool focus = false, bool scroll = false);
     void ExpandPathToItem(const CTreeListItem* item);
     void DrawNode(CDC* pdc, CRect& rc, CRect& rcPlusMinus, const CTreeListItem* item, int* width);
     void EnsureItemVisible(const CTreeListItem* item);

--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -1624,7 +1624,7 @@ void CDirStatDoc::OnTreeMapSelectParent()
 {
     const auto & item = CFileTreeControl::Get()->GetFirstSelectedItem<CItem>();
     PushReselectChild(item);
-    CFileTreeControl::Get()->SelectItem(item->GetParent(), true, true);
+    CFileTreeControl::Get()->SelectItem(item->GetParent(), true, true, true);
     UpdateAllViews(nullptr, HINT_SELECTIONREFRESH);
 }
 
@@ -1632,7 +1632,7 @@ void CDirStatDoc::OnTreeMapReselectChild()
 {
     const CItem* item = PopReselectChild();
     CFileTreeControl::Get()->ExpandPathToItem(item); // ensure item is visible before selecting
-    CFileTreeControl::Get()->SelectItem(item, true, true);
+    CFileTreeControl::Get()->SelectItem(item, true, true, true);
     UpdateAllViews(nullptr, HINT_SELECTIONREFRESH);
 }
 


### PR DESCRIPTION
- Ensure selected item visible on All Files view when navigating file tree using Select Parent and Reselect Child in TreeMap view