### PR TITLE
Tweak Document Icon

### DIFF
--- a/windirstat/Controls/IconHandler.cpp
+++ b/windirstat/Controls/IconHandler.cpp
@@ -187,8 +187,8 @@ namespace Icons
         SolidBrush lineBrush(Neutral());
         Point body[] = { {8, 6}, {44, 6}, {56, 18}, {56, 58}, {8, 58} };
         g.DrawPolygon(&outlinePen, body, 5);
-        g.DrawLine(&outlinePen, 44, 6, 44, 18);
-        g.DrawLine(&outlinePen, 44, 18, 56, 18);
+        Point docFoldPts[] = { {44, 6}, {44, 18}, {56, 18} };
+        g.DrawLines(&outlinePen, docFoldPts, 3);
     }
 
     static void PaintBin(Graphics& g, Color body, Color bar)


### PR DESCRIPTION
Fix the noticable broken tip at the folded corner of the document.

Before
<img width="610" height="78" alt="image" src="https://github.com/user-attachments/assets/03ccc0fc-dbab-46e1-ac10-e60eefa91240" />

After
<img width="614" height="75" alt="image" src="https://github.com/user-attachments/assets/b80ff1d8-296f-48fd-88c5-fadbb287fedb" />
