### PR TITLE
Address File Watcher Crash Issue

### DIFF
--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -892,7 +892,7 @@ void CDirStatDoc::OnUpdateCentralHandler(CCmdUI* pCmdUI)
     // special conditions
     static auto doc = this;
     static bool (*isZoomed)(CItem*) = [](CItem*) { return CDirStatDoc::Get()->IsZoomed(); };
-    static bool (*canZoomIn)(CItem*) = [](CItem* item) { return item != nullptr && (item = item->IsLeaf() ? item->GetParent() : item) != doc->GetZoomItem() && item->TmiGetSize() > 0; };
+    static bool (*canZoomIn)(CItem*) = [](CItem* item) { return item != nullptr && (item = item->IsLeaf() ? item->GetParent() : item) != nullptr && item != doc->GetZoomItem() && item->TmiGetSize() > 0; };
     static bool (*canZoomOut)(CItem*) = [](CItem*) { return doc->GetZoomItem() != doc->GetRootItem(); };
     static bool (*parentNotNull)(CItem*) = [](CItem* item) { return item != nullptr && item->GetParent() != nullptr; };
     static bool (*reselectAvail)(CItem*) = [](CItem*) { return doc->IsReselectChildAvailable(); };


### PR DESCRIPTION
Without the second `!= nullptr` there would be Access violation exception thrown at canZoomIn due to item might be null.
Tested both `!= nullptr` are required.