### PR TITLE
Restore Visual Studio stale file cache path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.vs/
 /publish/
 /build/
+/enc_temp_folder/
 intermediate/
 *.aps
 *.bin


### PR DESCRIPTION
Restoration of PR #219, which recently being removed in 9c377e888be6fe88e52b6c1bab53dabae0be1ba0