### PR TITLE
Fix: progress bar drops from 100% back to 99% at end of scan 02/06

### DIFF
--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -1978,6 +1978,17 @@ void CDirStatDoc::StartScanningEngine(std::vector<CItem*> items)
                 drive->RemoveHardlinksItem();
             }
         });
+        // After hardlink adjustment GetProgressPos() holds the corrected scan-based size.
+        // Resync the progress range to this value so position and range share exactly the
+        // same calculation basis — they will converge to 100%, not drop to 99%.
+        // Using GetProgressRange() (GetFreeDiskSpace) here would still be a mismatch.
+        {
+            const ULONGLONG correctedRange = GetRootItem()->GetProgressPos();
+            CMainFrame::PostToMessageThread([correctedRange]
+            {
+                CMainFrame::Get()->UpdateProgressRange(correctedRange);
+            });
+        }
 
         // If new scan or closing, indicate done and exit early
         if (stopReason == Abort)

--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -484,6 +484,14 @@ void CMainFrame::CreateProgress(ULONGLONG range)
     }
 }
 
+void CMainFrame::UpdateProgressRange(const ULONGLONG range)
+{
+    // Resync the range after hardlink adjustment so that the scan-based position
+    // and the range share the same calculation basis, converging exactly at 100%.
+    if (m_progressVisible && m_progressRange > 0)
+        m_progressRange = range;
+}
+
 void CMainFrame::SetProgressComplete()
 {
     // Disable any potential suspend state

--- a/windirstat/MainFrame.h
+++ b/windirstat/MainFrame.h
@@ -171,6 +171,7 @@ protected:
     CExtensionView* GetExtensionView() const { return m_extensionView; }
 
     void CreateProgress(ULONGLONG range);
+    void UpdateProgressRange(ULONGLONG range);
     void SetProgressComplete();
     void SuspendState(bool suspend);
     bool IsScanSuspended() const;


### PR DESCRIPTION
# Fix: Progress bar drops from 100% back to 99% at end of scan

## Background — why I made this change
To be honest with you before:
I'm not really a programmer. I'm just a regular WinDirStat user who got frustrated enough with this specific bug to actually do something about it.
I want to be transparent about that: I didn't write this patch alone from memory 
I worked through it step by step with AI assistance. But the root cause analysis is real, the fix is correct, and it was tested on my machine.

**What this means for you as a user:** 
The progress bar now reaches 100% and stays there. 
Clean, correct, no more backward jump right at the end. 
A small change that makes the whole application feel more polished.

## Symptom

Near the end of a scan on a drive with hardlinks, the progress bar reaches 100%, then immediately snaps back to 99% and stays there briefly before the scan completes. On slower machines this can be visible for several seconds and looks like a bug to users.

## Root Cause

The progress percentage is `position / range * 100`. The numerator and denominator are computed using two different bases, and they diverge after hardlink adjustment.

**Range (denominator):** Set once at scan start from `GetProgressRangeDrive()`, which calls `GetFreeDiskSpace()`:
```
range = total_disk_space - free_disk_space   ← OS-reported value
```

**Position (numerator):** Accumulated by scan threads via `GetProgressPos()`:
```
pos = GetSizePhysical() - freeSpaceItem.GetSizePhysical()   ← scan-accumulated value
```

During scanning, hardlinks are counted multiple times (each name counts toward `GetSizePhysical()`). After the scan, `DoHardlinkAdjustment()` subtracts the overcounted size. This reduces `GetSizePhysical()`, which reduces `GetProgressPos()`.

At this point:
- `range` is still the original OS disk space (e.g. 500 GB)  
- `pos` has just been reduced by the hardlink deduplication (e.g. dropped from 500 GB to 495 GB)
- Result: 495 / 500 = 99%

The range was set from one basis, the position is now on a different basis — they can never converge at 100%.

## Files Changed

| File | Change |
|---|---|
| `windirstat/MainFrame.h` | Declared `UpdateProgressRange(ULONGLONG range)` |
| `windirstat/MainFrame.cpp` | Implemented `UpdateProgressRange` |
| `windirstat/DirStatDoc.cpp` | Called `UpdateProgressRange` after `DoHardlinkAdjustment` |

## The Fix

After `DoHardlinkAdjustment` completes, resync `m_progressRange` to the value returned by `GetProgressPos()`. Now both numerator and denominator are on the same scan-accumulated basis, and they converge exactly at 100%.

```cpp
// DirStatDoc.cpp — after DoHardlinkAdjustment
const ULONGLONG correctedRange = GetRootItem()->GetProgressPos();
CMainFrame::PostToMessageThread([correctedRange]
{
    CMainFrame::Get()->UpdateProgressRange(correctedRange);
});
```

```cpp
// MainFrame.cpp
void CMainFrame::UpdateProgressRange(const ULONGLONG range)
{
    if (m_progressVisible && m_progressRange > 0)
        m_progressRange = range;
}
```

The call is posted to the message thread so it executes on the UI thread where `m_progressRange` is owned.

## Why This Is Correct and Not a Band-Aid

A previous candidate fix was a flag `m_progressReachedMax` that prevented the bar from going backwards. That is a band-aid: it hides the symptom while the underlying mismatch remains. It was rejected.

This fix addresses the root cause: after adjustment, the denominator is resynced to match the numerator's calculation basis. The two values are now in the same unit — scan-accumulated physical bytes minus free space — and they converge at the same number.

The fix also covers the `ProcessHardlinks=false` branch: when hardlinks were previously detected and the hardlinks item is removed, `RemoveHardlinksItem` also changes `GetSizePhysical()`. The resync call is placed after both the `if` and `else` branches, so it handles both cases.
