### PR TITLE
Fix: WinDirStat hangs or shuts down slowly after a scan 05/06

### DIFF
--- a/windirstat/Controls/IconHandler.cpp
+++ b/windirstat/Controls/IconHandler.cpp
@@ -23,7 +23,10 @@ CIconHandler::~CIconHandler()
 {
     for (auto* queue : { &m_fastQueue, &m_slowQueue })
     {
-        queue->SuspendExecution();
+        // Interrupt any blocking SHGetFileInfo/ReadFile in workers so they return
+        // quickly to their Pop() loop where they will see CancelExecution's flag.
+        // Without this, the destructor can hang until the current icon fetch completes.
+        queue->CancelThreadIo();
         queue->CancelExecution();
     }
 }
@@ -115,6 +118,7 @@ void CIconHandler::ClearAsyncShellInfoQueue()
     {
         for (auto* queue : { &m_fastQueue, &m_slowQueue })
         {
+            queue->CancelThreadIo();
             queue->SuspendExecution(true);
             queue->ResumeExecution();
         }
@@ -127,6 +131,7 @@ void CIconHandler::StopAsyncShellInfoQueue()
     {
         for (auto* queue : { &m_fastQueue, &m_slowQueue })
         {
+            queue->CancelThreadIo();
             queue->SuspendExecution();
             queue->CancelExecution();
         }


### PR DESCRIPTION
# Fix: WinDirStat hangs or shuts down slowly after a scan

## Background — why I made this change
To be honest with you before:
I'm not really a programmer. I'm just a regular WinDirStat user who got frustrated enough with this specific bug to actually do something about it.
I want to be transparent about that: I didn't write this patch alone from memory 
I worked through it step by step with AI assistance. But the root cause analysis is real, the fix is correct, and it was tested on my machine.
(yeh i repeat at this point the multiple times my self, because i like to be honest)


I got here because I was already digging into why WinDirStat wouldn't close quickly, and once you find one bug of a certain type you start looking for others like it.
After fixing the main scan-hang (patch 01), I noticed that closing WinDirStat after a scan 
or starting a new scan right after finishing one still had a small but annoying delay. 
The application would take a moment to become responsive again, even though the scan was done. 
On machines with network drives or slow shell extensions, this delay may be longer and sometimes looked like a crash for me.
I investigated this together with Claude (Anthropic's AI), which helped me trace the same class of deadlock into the icon loading subsystem. 
I want to be clear about that: AI assistance was used throughout. 
But having found and fixed the root cause in the scan threads, finding the same issue in the icon handler was a matter of knowing where to look.

**What this means for you as a user:** WinDirStat closes and resets faster. Starting a new scan after finishing one is more responsive. The little pause after a completed scan — especially noticeable on systems with many shell extensions — is gone. These are the kinds of polish fixes that make an application feel solid rather than just functional.

## Symptom

After a scan completes (or when the application is closed), WinDirStat takes several seconds longer than expected to shut down or to rebuild its icon cache. On systems with slow shell extensions or network drives, this delay can exceed 10 seconds. In the worst case, the application hangs indefinitely during teardown.

## Root Cause

Same class of bug as the scan-hang fix (patch 01), but in `CIconHandler`.

`CIconHandler` runs two `BlockingQueue` instances (`m_fastQueue`, `m_slowQueue`) whose worker threads call `FetchShellIcon` → `SHGetFileInfo`. `SHGetFileInfo` internally opens files and reads icon data via `ReadFile`-level I/O. While a worker is in this call, it is not inside `Pop()` and not inside `WaitIfSuspended()`, so `AllThreadsIdling()` returns false.

Three call sites were affected:

**1. The destructor (`~CIconHandler`):**
```cpp
// BEFORE — hangs on UI thread until current SHGetFileInfo returns
queue->SuspendExecution();  // waits for AllThreadsIdling() — never true if worker in I/O
queue->CancelExecution();
```
The destructor runs on the UI thread. Without `CancelThreadIo`, the UI thread blocks until the current icon fetch naturally completes. If the worker is fetching an icon from a network path, this is unbounded.

**2. `ClearAsyncShellInfoQueue`** — called when a new scan starts to flush the icon queue. Uses `ProcessMessagesUntilSignaled`, so the UI doesn't fully freeze, but the operation takes longer than necessary.

**3. `StopAsyncShellInfoQueue`** — called when the scan engine is stopped. Same issue.

## Files Changed

| File | Change |
|---|---|
| `windirstat/Controls/IconHandler.cpp` | Add `CancelThreadIo()` before every `SuspendExecution()` / `CancelExecution()` call |

## The Fix

For the destructor, `SuspendExecution` is unnecessary — in a destructor you just want to cancel and join, not pause-and-resume. Replacing it with `CancelThreadIo` + `CancelExecution` is both correct and simpler:

```cpp
CIconHandler::~CIconHandler()
{
    for (auto* queue : { &m_fastQueue, &m_slowQueue })
    {
        // Interrupt any blocking SHGetFileInfo/ReadFile in workers so they return
        // quickly to their Pop() loop where they will see CancelExecution's flag.
        queue->CancelThreadIo();
        queue->CancelExecution();
    }
}
```

For `ClearAsyncShellInfoQueue` and `StopAsyncShellInfoQueue`, `CancelThreadIo` is prepended:

```cpp
queue->CancelThreadIo();
queue->SuspendExecution(true);  // or SuspendExecution()
queue->ResumeExecution();       // or CancelExecution()
```

## Why Not a Band-Aid

`CancelSynchronousIo` interrupts the actual blocking call (`ReadFile` inside `SHGetFileInfo`). The worker returns from its I/O, handles the `ERROR_OPERATION_ABORTED` result gracefully (icon fetch fails, fallback icon is used or item is skipped), and reaches the idle state in its `Pop()` loop. The underlying deadlock is resolved, not masked.
