### PR TITLE
Sec-fix: quote path substitutions in User Defined Cleanup command lines

### DIFF
--- a/windirstat/DirStatDoc.cpp
+++ b/windirstat/DirStatDoc.cpp
@@ -763,11 +763,28 @@ std::wstring CDirStatDoc::BuildUserDefinedCleanupCommandLine(const std::wstring 
     ReplaceString(s, L"%sp", L">sp");
     ReplaceString(s, L"%sn", L">sn");
 
-    // Now substitute
-    ReplaceString(s, L">p", rootPath);
-    ReplaceString(s, L">n", rootName);
-    ReplaceString(s, L">sp", currentPath);
-    ReplaceString(s,L">sn", currentName);
+    // Substitute each marker, adding surrounding quotes unless the user's command
+    // template already wraps the placeholder in double quotes (e.g. "%p").
+    // Quoting prevents CMD metacharacter injection (&, |, ^, etc.) from path
+    // components. Windows paths cannot contain '"', so no inner-quote escaping
+    // is needed.
+    auto SubstQuoted = [&s](const std::wstring& marker, const std::wstring& value)
+    {
+        size_t pos = 0;
+        while ((pos = s.find(marker, pos)) != std::wstring::npos)
+        {
+            const bool alreadyQuoted = pos > 0 && s[pos - 1] == L'"' &&
+                pos + marker.size() < s.size() && s[pos + marker.size()] == L'"';
+            const std::wstring repl = alreadyQuoted ? value : (L'"' + value + L'"');
+            s.replace(pos, marker.size(), repl);
+            pos += repl.size();
+        }
+    };
+
+    SubstQuoted(L">p",  rootPath);
+    SubstQuoted(L">n",  rootName);
+    SubstQuoted(L">sp", currentPath);
+    SubstQuoted(L">sn", currentName);
 
     return s;
 }


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance (Claude Code). I reviewed and tested the result, but the implementation was largely AI-generated.

## Summary

`BuildUserDefinedCleanupCommandLine` substitutes the `%p`, `%n`, `%sp`, and `%sn` placeholders into user-supplied command templates without quoting the path values. The result is passed verbatim to `CMD.EXE /C`, which interprets unquoted `&`, `|`, `<`, `>`, and `^` as shell metacharacters.

Windows permits these characters in directory names. A directory named `legit project & calc.exe` produces this expansion for the template `ROBOCOPY %p D:\backup\`:

```
CMD.EXE /C ROBOCOPY legit project & calc.exe D:\backup\
```

CMD.EXE sees two separate commands: `ROBOCOPY legit project` and `calc.exe`.

## Where this matters

The scenario is most realistic on **shared network storage**:

1. A user has one or more UDCs configured (e.g. a backup or archive command).
2. The user scans an SMB share in WinDirStat.
3. An attacker with write access to the share has created a folder whose name contains CMD metacharacters (e.g. `reports & powershell -enc <payload>`).
4. The user right-clicks that folder in WinDirStat and applies a UDC — the payload executes in the user's security context.

The same applies to ZIP archives or any other source of attacker-controlled directory names.

**Limiting preconditions:** The user must have at least one UDC enabled (none are by default) and must explicitly apply it to the specific item.

## Fix

Replaces the four bare `ReplaceString` calls with a `SubstQuoted` lambda that:

- **If the placeholder is not quoted in the template** (e.g. bare `%p`): wraps the substituted value in double quotes → `"C:\path\to\item"`.
- **If the placeholder is already quoted** (e.g. `"%p"`): substitutes the raw value, avoiding double-quoting that would break paths with spaces.

Windows paths cannot contain `"`, so no inner-quote escaping is required.

**Side effect:** This also silently fixes the pre-existing issue where paths containing spaces would cause CMD to split the argument (`ROBOCOPY C:\My Documents D:\backup\` passes `C:\My` and `Documents` as separate arguments).

## Code quality note

I did a broader read-only review of the codebase while preparing this PR. The code is genuinely well-structured for a project of this age — consistent typed registry I/O via `Setting<T>`, clean NTFS→FinderBasic fallback, proper `regex_error` handling, and no widespread insecure patterns. That made it straightforward to audit.

I found five lower-severity observations I'm listing here **for maintainer awareness only**:

<details>
<summary>Informational findings (no action required)</summary>

**CR-01 — `CsvLoader.cpp`: `ITEMTYPE` cast without range check**
`static_cast<ITEMTYPE>(wcstoull(..., 16))` casts an external hex value to an enum with no validity check. A corrupted `.wds` file could supply an out-of-range value, resulting in UB in the dispatch code (in practice likely a silent wrong-type node, not a crash).

**CR-02 — `CsvLoader.cpp`: Incomplete JSON escape sequences**
The hand-rolled JSON parser handles only `\\` and `\"`. Missing: `\n`, `\r`, `\t`, `\b`, `\f`, `\uXXXX`. File names containing these sequences in a saved JSON scan result would round-trip back with literal `\n` etc. instead of the actual characters.

**CR-03 — `CsvLoader.cpp`: CSV parser doesn't implement RFC 4180 `""` quoting**
Embedded `"` characters in file names are written as `""` in quoted CSV fields (RFC 4180), but the current parser doesn't handle the `""` → `"` unescaping. Such entries would be mis-tokenized on reload.

**CR-04 — `CsvLoader.cpp`: `static z_stream*` in `GetCompressedResource` is not thread-safe**
The zlib decompression context is a static pointer reused across calls. No guard enforces the implicit assumption that the function is only called single-threaded at startup.

**CR-05 — `Property.cpp`: `std::stoi` without exception handling**
`Setting<std::vector<int>>::ReadPersistedProperty` calls `std::stoi(token)` without a `try/catch`. A trailing comma or non-numeric value in the registry entry would throw `std::invalid_argument` and crash the app at startup.

If any of these are worth addressing, feel free to let me know and I'll submit a separate PR.

</details>

---

Tested on Windows 11 x64. Verified both cases: bare `%p` and `"%p"` in the command template, with directory names containing `&`, `|`, and spaces.