### PR TITLE
Address Language Fallback Logic Regression

### DIFF
--- a/windirstat/Localization.cpp
+++ b/windirstat/Localization.cpp
@@ -112,14 +112,12 @@ bool Localization::LoadResource(const WORD language)
     std::array<wchar_t, LOCALE_NAME_MAX_LENGTH> name{};
     if (LCIDToLocaleName(lcid, name.data(), LOCALE_NAME_MAX_LENGTH, 0) == 0) return true;
 
-    // Try to load external language file first
-    if (LoadExternalLanguage(LOCALE_SNAME, language) ||
-        LoadExternalLanguage(LOCALE_SISO639LANGNAME, language)) return true;
-
-    // Try to load built-in resource
-    CrackStrings(sResourceData, GetLocaleString(LOCALE_SNAME, language));
-    CrackStrings(sResourceData, GetLocaleString(LOCALE_SISO639LANGNAME, language));
-    return true;
+    // Short-circuit language resource loading sequence, first successful load will return true and exit the function
+    return
+        LoadExternalLanguage(LOCALE_SNAME, language) ||                                 // External BCP 47 language file
+        LoadExternalLanguage(LOCALE_SISO639LANGNAME, language) ||                       // External ISO 639-1 language file
+        CrackStrings(sResourceData, GetLocaleString(LOCALE_SNAME, language)) ||         // Built-in BCP 47 resource
+        CrackStrings(sResourceData, GetLocaleString(LOCALE_SISO639LANGNAME, language)); // Built-in ISO 639-1 resource
 }
 
 void Localization::UpdateMenu(CMenu& menu)


### PR DESCRIPTION
Address language fallback logic regression introduced by refactoring in f9ada432f4c59f9d109452f27d4f628ceb97462d that altered short-circuit return evaluation fallback logic, causing loaded internal zh-HK overwritten by zh.

### Force-push Log
- f6b6fe01a6d06bbd3c53ce36f96c898828fe0802 Refactor to combine 2 short-circuit pattern into a single one
- b938897859d1d45e7982476dab172af225e559f7 Comment wording changes