### PR TITLE
Clearing Status Pane Text During Scan

### DIFF
--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -598,6 +598,7 @@ void CMainFrame::UpdateProgress()
 
 void CMainFrame::CreateStatusProgress()
 {
+    UpdatePaneText();
     if (m_progress.m_hWnd == nullptr)
     {
         CRect rc;
@@ -649,6 +650,7 @@ void CMainFrame::DestroyProgress()
 
     m_workingItem = nullptr;
     m_progressVisible = false;
+    UpdatePaneText();
 }
 
 void CMainFrame::SetStatusPaneText(const CDC& cdc, const int pos,
@@ -1230,7 +1232,8 @@ void CMainFrame::MoveFocus(const LOGICAL_FOCUS logicalFocus)
 void CMainFrame::UpdatePaneText()
 {
     const auto focus = GetLogicalFocus();
-    std::wstring fileSelectionText = Localization::Lookup(IDS_IDLEMESSAGE);
+    std::wstring fileSelectionText = !CDirStatDoc::Get()->IsScanRunning() ?
+        Localization::Lookup(IDS_IDLEMESSAGE) : wds::strEmpty;
     ULONGLONG size = MAXULONGLONG;
 
     // Allow override on hover


### PR DESCRIPTION
Address issue that part of the text visible underneath the progress bar during scan, while maintaining the intended aesthetic of the progress bar in cda9d60a459c9f095de1a52b5894e81ad187ae0e.

<img width="118" height="48" alt="image" src="https://github.com/user-attachments/assets/5f01c10f-4835-4fa6-89a9-ba4edf703aaa" />
