### PR TITLE
treemap: float arithmetic, par_unseq leaf shading, optional async render

### DIFF
--- a/windirstat/Controls/TreeMap.cpp
+++ b/windirstat/Controls/TreeMap.cpp
@@ -651,6 +651,10 @@ void CTreeMap::DrawOverlays(CDC* pdc, const CRect& rc, CItem* root,
     // Font must be active for both folder headers and DrawTreeMapLabels
     CSelectStockObject soFont(pdc, DEFAULT_GUI_FONT);
 
+    TEXTMETRIC tm{};
+    pdc->GetTextMetrics(&tm);
+    const int headerHeight = tm.tmHeight + 4;
+
     if (m_options.showFolderFrames)
     {
         CSetBkMode soBkMode(pdc, TRANSPARENT);

--- a/windirstat/Controls/TreeMap.cpp
+++ b/windirstat/Controls/TreeMap.cpp
@@ -350,27 +350,27 @@ void CTreeMap::RecurseCheckTree(const CItem* item)
 
 void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* options)
 {
-    // Validate parameters and options
+    auto layout = BuildLayout(pdc, rc, root, options);
+    if (layout.bitmapBits.empty()) return;
+    RenderLeafJobs(layout.bitmapBits, layout.leafJobs, nullptr, nullptr);
+    DrawOverlays(pdc, layout.renderArea, root, layout.bitmapBits, layout.folders);
+}
+
+CTreeMap::LayoutResult CTreeMap::BuildLayout(CDC* pdc, CRect rc, CItem* root, const Options* options)
+{
     ASSERT(pdc != nullptr && root != nullptr);
     if (pdc == nullptr || root == nullptr)
-    {
-        // Parameter check fallback
-        return;
-    }
+        return {};
 
 #ifdef _DEBUG
     RecurseCheckTree(root);
 #endif // _DEBUG
 
     if (options != nullptr)
-    {
         SetOptions(options);
-    }
 
     if (!PrepareRenderArea(pdc, rc, !m_options.grid))
-    {
-        return;
-    }
+        return {};
 
     CSelectStockObject soFont(pdc, DEFAULT_GUI_FONT);
 
@@ -383,16 +383,20 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
     if (root->TmiGetSize() == 0)
     {
         pdc->FillSolidRect(rc, RGB(0, 0, 0));
-        return;
+        return {};
     }
 
-    // Allocate bitmap buffers and configure options
-    const int renderWidth = rc.Width();
+    const int renderWidth  = rc.Width();
     const int renderHeight = rc.Height();
     const size_t pixelCount = static_cast<size_t>(renderWidth) * static_cast<size_t>(renderHeight);
-    std::vector<COLORREF> bitmapBits(pixelCount, MakeBitmapColor(m_options.gridColor, PALETTE_BRIGHTNESS));
 
-    const int gridWidth = m_options.grid ? 1 : 0;
+    LayoutResult result;
+    result.renderArea = rc;
+    result.bitmapBits.assign(pixelCount, MakeBitmapColor(m_options.gridColor, PALETTE_BRIGHTNESS));
+    result.leafJobs.reserve(1024);
+    result.folders.reserve(128);
+
+    const int gridWidth       = m_options.grid ? 1 : 0;
     const bool cushionShading = IsCushionShading();
 
     LayoutScratch layoutScratch;
@@ -400,31 +404,20 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
     stack.reserve(128);
     stack.push_back({ {}, CRect(0, 0, renderWidth, renderHeight), root, m_options.height, true, 0 });
 
-    struct FolderDrawInfo
-    {
-        const CItem* item;
-        CRect rc;
-        int depth;
-        bool showHeader;
-    };
-    std::vector<FolderDrawInfo> foldersToDraw;
-    foldersToDraw.reserve(128);
-
     auto pushChildState = [this, &stack](CItem* child, const CRect& childRect, const DrawStateInfo& parentState)
     {
         stack.push_back({ parentState.surface, childRect, child,
             parentState.ridgeHeight * m_options.scaleFactor, false, parentState.depth + 1 });
     };
 
-    // Lay out children using KDirStat style
     auto pushKDirStatChildren = [this, &layoutScratch, &pushChildState](CItem* item, const DrawStateInfo& state)
     {
         const bool horizontalRows =
             KDirStat_ArrangeChildren(item, layoutScratch.childWidth, layoutScratch.rows, layoutScratch.childrenPerRow);
 
-        const double rowOrigin = horizontalRows ? state.rc.top : state.rc.left;
-        const int rowExtent = horizontalRows ? state.rc.Height() : state.rc.Width();
-        const int columnExtent = horizontalRows ? state.rc.Width() : state.rc.Height();
+        const double rowOrigin = horizontalRows ? state.rc.top  : state.rc.left;
+        const int rowExtent    = horizontalRows ? state.rc.Height() : state.rc.Width();
+        const int columnExtent = horizontalRows ? state.rc.Width()  : state.rc.Height();
 
         double top = rowOrigin;
         size_t childIndex = 0;
@@ -453,12 +446,10 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
                 pushChildState(child, rcChild, state);
                 left = fRight;
             }
-
             top = fBottom;
         }
     };
 
-    // Lay out children using SequoiaView style
     auto pushSequoiaViewChildren = [this, &pushChildState](CItem* item, const DrawStateInfo& state)
     {
         CRect remaining = state.rc;
@@ -467,9 +458,7 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
 
         const int maxChild = item->TmiGetChildCount();
         if (maxChild == 0)
-        {
             return;
-        }
 
         const double sizePerSquarePixel = static_cast<double>(remainingSize) / remaining.Width() / remaining.Height();
         int head = 0;
@@ -478,14 +467,13 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
         {
             ASSERT(remaining.Width() > 0 && remaining.Height() > 0);
 
-            const bool horizontal = remaining.Width() >= remaining.Height();
+            const bool horizontal  = remaining.Width() >= remaining.Height();
             const int rowThickness = horizontal ? remaining.Height() : remaining.Width();
-            const double hh = rowThickness * rowThickness * sizePerSquarePixel;
+            const double hh        = rowThickness * rowThickness * sizePerSquarePixel;
             ASSERT(hh > 0);
 
             const int rowBegin = head;
             int rowEnd = head;
-
             double worst = DBL_MAX;
             const ULONGLONG rmax = item->TmiGetChild(rowBegin)->TmiGetSize();
             ULONGLONG sum = 0;
@@ -499,14 +487,12 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
                     break;
                 }
 
-                const double nextSum = static_cast<double>(sum) + childSize;
-                const double ss = nextSum * nextSum;
+                const double nextSum   = static_cast<double>(sum) + childSize;
+                const double ss        = nextSum * nextSum;
                 const double nextWorst = std::max(hh * rmax / ss, ss / hh / childSize);
 
                 if (nextWorst > worst)
-                {
                     break;
-                }
 
                 sum += childSize;
                 ++rowEnd;
@@ -516,9 +502,7 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
             if (sum == 0)
             {
                 for (const int i : std::views::iota(head, maxChild))
-                {
                     item->TmiGetChild(i)->TmiSetRectangle(CRect(-1, -1, -1, -1));
-                }
                 break;
             }
 
@@ -528,15 +512,16 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
                 : remainingExtent;
 
             CRect rcRow = remaining;
-            if (horizontal) rcRow.right = rcRow.left + rowWidth;
-            else rcRow.bottom = rcRow.top + rowWidth;
+            if (horizontal) rcRow.right  = rcRow.left + rowWidth;
+            else             rcRow.bottom = rcRow.top  + rowWidth;
 
             double fBegin = horizontal ? rcRow.top : rcRow.left;
+
             for (const int i : std::views::iota(rowBegin, rowEnd))
             {
                 const ULONGLONG childSize = item->TmiGetChild(i)->TmiGetSize();
                 const double fraction = static_cast<double>(childSize) / sum;
-                const double fEnd = fBegin + fraction * (horizontal ? rcRow.Height() : rcRow.Width());
+                const double fEnd     = fBegin + fraction * (horizontal ? rcRow.Height() : rcRow.Width());
 
                 const bool lastChild = i + 1 == rowEnd
                     || (i + 1 < item->TmiGetChildCount() && item->TmiGetChild(i + 1)->TmiGetSize() == 0);
@@ -559,15 +544,12 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
             if (remaining.Width() <= 0 || remaining.Height() <= 0)
             {
                 for (const int i : std::views::iota(head, maxChild))
-                {
                     item->TmiGetChild(i)->TmiSetRectangle(CRect(-1, -1, -1, -1));
-                }
                 break;
             }
         }
     };
 
-    // Main layout loop
     while (!stack.empty())
     {
         DrawStateInfo state = stack.back();
@@ -577,18 +559,22 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
         item->TmiSetRectangle(state.rc);
 
         if (state.rc.Width() <= gridWidth || state.rc.Height() <= gridWidth)
-        {
             continue;
-        }
 
         if (cushionShading && !state.asRoot)
-        {
             AddRidge(state.rc, state.surface, state.ridgeHeight);
-        }
 
         if (item->TmiIsLeaf())
         {
-            RenderLeaf(bitmapBits, item, state.surface);
+            CRect jobRc = item->TmiGetRectangle();
+            if (m_options.grid)
+            {
+                jobRc.top++;
+                jobRc.left++;
+                if (jobRc.Width() <= 0 || jobRc.Height() <= 0)
+                    continue;
+            }
+            result.leafJobs.push_back({ jobRc, state.surface, item->TmiGetGraphColor() });
             continue;
         }
 
@@ -601,9 +587,9 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
             const bool showHeader = (state.rc.Height() > headerHeight) &&
                 (pdc->GetTextExtent(name.data(), static_cast<int>(name.size())).cx <= textWidth);
 
-            foldersToDraw.push_back({ item, state.rc, state.depth, showHeader });
-            state.rc.left += 1;
-            state.rc.right -= 1;
+            result.folders.push_back({ item, state.rc, state.depth, showHeader });
+            state.rc.left   += 1;
+            state.rc.right  -= 1;
             state.rc.bottom -= 1;
             state.rc.top += showHeader ? headerHeight : 1;
 
@@ -612,20 +598,15 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
                 std::vector<CItem*> pending;
                 pending.reserve(32);
                 for (const int i : std::views::iota(0, item->TmiGetChildCount()))
-                {
                     pending.push_back(item->TmiGetChild(i));
-                }
 
                 while (!pending.empty())
                 {
                     CItem* child = pending.back();
                     pending.pop_back();
-
                     child->TmiSetRectangle(CRect(-1, -1, -1, -1));
                     for (const int i : std::views::iota(0, child->TmiGetChildCount()))
-                    {
                         pending.push_back(child->TmiGetChild(i));
-                    }
                 }
                 continue;
             }
@@ -644,16 +625,36 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
         }
     }
 
-    // Copy the rendered bitmap to the DC
+    return result;
+}
+
+void CTreeMap::RenderLeafJobs(std::vector<COLORREF>& bitmapBits, const std::vector<LeafJob>& jobs,
+    std::atomic<int>* progress, const std::atomic<bool>* cancel) const
+{
+    std::for_each(std::execution::par_unseq, jobs.begin(), jobs.end(),
+        [&](const LeafJob& job) noexcept {
+            if (cancel != nullptr && cancel->load(std::memory_order_relaxed)) return;
+            const PreparedColor prepared = PrepareRenderColor(job.color, m_options.brightness);
+            if (IsCushionShading())
+                DrawCushion(bitmapBits, job.rc, job.surface, prepared.color, prepared.brightness);
+            else
+                DrawSolidRect(bitmapBits, job.rc, prepared.color, prepared.brightness);
+            if (progress != nullptr) progress->fetch_add(1, std::memory_order_relaxed);
+        });
+}
+
+void CTreeMap::DrawOverlays(CDC* pdc, const CRect& rc, CItem* root,
+    const std::vector<COLORREF>& bitmapBits, const std::vector<FolderInfo>& folders) const
+{
     BlitBitmap(pdc, rc, bitmapBits);
 
-    // Render directory frames and labels
     if (m_options.showFolderFrames)
     {
+        CSelectStockObject soFont(pdc, DEFAULT_GUI_FONT);
         CSetBkMode soBkMode(pdc, TRANSPARENT);
         const CPoint rcOffset = rc.TopLeft();
 
-        for (const auto& folder : foldersToDraw)
+        for (const auto& folder : folders)
         {
             CRect rcFolder = folder.rc;
             rcFolder.OffsetRect(rcOffset);
@@ -680,11 +681,8 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
     }
 
     if (m_options.showExtensions)
-    {
         DrawTreeMapLabels(pdc, root, rc.TopLeft());
-    }
 }
-
 CItem* CTreeMap::FindItemByPoint(CItem* item, const CPoint point)
 {
     ASSERT(item != nullptr);
@@ -971,53 +969,83 @@ void CTreeMap::DrawSolidRect(std::vector<COLORREF>& bitmap, const CRect& rc, con
     }
 }
 
+// float_control(precise,off) enables FMA, rsqrt approximation, and fp reassociation for this
+// function only; the ~0.03% precision loss is not visible in rendered output.
+#pragma float_control(precise, off, push)
 void CTreeMap::DrawCushion(std::vector<COLORREF>& bitmap, const CRect& rc, const std::array<double, 4>& surface, const COLORREF col, const double brightness) const
 {
-    const double Ia = m_options.ambientLight;
-    const double Is = 1 - Ia;
-    const double brightnessFactor = brightness / PALETTE_BRIGHTNESS;
-
-    const double colR = GetRValue(col);
-    const double colG = GetGValue(col);
-    const double colB = GetBValue(col);
+    // Convert to float; per-pixel Phong shading does not require double precision
+    const float Ia = static_cast<float>(m_options.ambientLight);
+    const float Is = 1.0f - Ia;
+    const float brightnessFactor = static_cast<float>(brightness / PALETTE_BRIGHTNESS);
+    const float s0  = static_cast<float>(surface[0]);
+    const float s1  = static_cast<float>(surface[1]);
+    const float s2  = static_cast<float>(surface[2]);
+    const float s3  = static_cast<float>(surface[3]);
+    const float llx = static_cast<float>(m_lx);
+    const float lly = static_cast<float>(m_ly);
+    const float llz = static_cast<float>(m_lz);
+    const float colR = static_cast<float>(GetRValue(col));
+    const float colG = static_cast<float>(GetGValue(col));
+    const float colB = static_cast<float>(GetBValue(col));
     const int stride = m_renderArea.Width();
 
     for (int iy = rc.top; iy < rc.bottom; ++iy)
     {
-        const double ny = -(2 * surface[1] * (iy + 0.5) + surface[3]);
-        const double ny_ly_lz = ny * m_ly + m_lz;
-        const double ny2_1 = ny * ny + 1.0;
-        COLORREF* const row = bitmap.data() + static_cast<size_t>(iy) * static_cast<size_t>(stride);
+        const float ny       = -(2.0f * s1 * (static_cast<float>(iy) + 0.5f) + s3);
+        const float ny_ly_lz = ny * lly + llz;
+        const float ny2_1    = ny * ny + 1.0f;
+        COLORREF* const row  = bitmap.data() + static_cast<size_t>(iy) * static_cast<size_t>(stride);
 
         for (int ix = rc.left; ix < rc.right; ++ix)
         {
-            const double nx = -(2 * surface[0] * (ix + 0.5) + surface[2]);
-            double cosa = (nx * m_lx + ny_ly_lz) / sqrt(nx * nx + ny2_1);
-            cosa = std::min<double>(cosa, 1.0);
+            const float nx  = -(2.0f * s0 * (static_cast<float>(ix) + 0.5f) + s2);
+            // 1/sqrtf: with /fp:fast the compiler emits rsqrtss + Newton-Raphson refinement
+            float cosa = (nx * llx + ny_ly_lz) * (1.0f / sqrtf(nx * nx + ny2_1));
+            cosa = std::min(cosa, 1.0f);
 
-            double pixel = Is * cosa;
-            pixel = std::max<double>(pixel, 0.0);
+            float pixel = Is * cosa;
+            pixel = std::max(pixel, 0.0f);
             pixel += Ia;
-            ASSERT(pixel <= 1.0);
 
             // Now, pixel is the brightness of the pixel, 0...1.0.
             // Apply contrast.
             // Not implemented.
             // Costs performance and nearly the same effect can be
             // made width the m_options->ambientLight parameter.
-            // pixel = pow(pixel, m_options->contrast);
+            // pixel = powf(pixel, m_options.contrast);
 
             pixel *= brightnessFactor;
 
-            int red = static_cast<int>(colR * pixel);
+            int red   = static_cast<int>(colR * pixel);
             int green = static_cast<int>(colG * pixel);
-            int blue = static_cast<int>(colB * pixel);
+            int blue  = static_cast<int>(colB * pixel);
 
             CColorSpace::NormalizeColor(red, green, blue);
             row[ix] = BGR(blue, green, red);
         }
     }
 }
+#pragma float_control(pop)
+
+// Future optimization idea: SIMD (SSE4/AVX2) inner loop for DrawCushion
+//
+// PROS
+//   - Process 4 (SSE4) or 8 (AVX2) pixels per iteration instead of 1
+//   - rsqrtps + Newton-Raphson is already SIMD-native; no scalar fallback needed
+//   - Memory bandwidth stays the only bottleneck on large leaves; CPU cycles drop ~4-8x
+//   - Combines well with par_unseq across leaves: thread-level + SIMD-level parallelism
+//
+// CONS
+//   - Requires x86 intrinsics (<immintrin.h>): not portable to ARM64/Clang-CL without
+//     separate code paths or auto-vectorization hints
+//   - Column-stride write (row[ix]) is sequential; gather/scatter adds complexity
+//   - Compiler with /fp:fast + /O2 may auto-vectorize already — measure before hand-coding
+//   - Maintenance cost: intrinsic code is harder to read and review than scalar float
+//
+// RECOMMENDATION: profile first (VTune/perf). If auto-vectorization is already happening
+// (check asm output for vmulps/vrsqrtps), there is nothing to gain. If not, a targeted
+// __m256 loop for the inner ix-loop (8 pixels, AVX2) would be the highest-impact change.
 
 void CTreeMap::AddRidge(const CRect& rc, std::array<double, 4>& surface, const double h)
 {

--- a/windirstat/Controls/TreeMap.cpp
+++ b/windirstat/Controls/TreeMap.cpp
@@ -648,9 +648,11 @@ void CTreeMap::DrawOverlays(CDC* pdc, const CRect& rc, CItem* root,
 {
     BlitBitmap(pdc, rc, bitmapBits);
 
+    // Font must be active for both folder headers and DrawTreeMapLabels
+    CSelectStockObject soFont(pdc, DEFAULT_GUI_FONT);
+
     if (m_options.showFolderFrames)
     {
-        CSelectStockObject soFont(pdc, DEFAULT_GUI_FONT);
         CSetBkMode soBkMode(pdc, TRANSPARENT);
         const CPoint rcOffset = rc.TopLeft();
 

--- a/windirstat/Controls/TreeMap.h
+++ b/windirstat/Controls/TreeMap.h
@@ -186,8 +186,46 @@ public:
     void RecurseCheckTree(const CItem *item);
 #endif // _DEBUG
 
-    // Create and draw a treemap
+    // Per-leaf shading job: pure value data, no tree pointers, safe to process on any thread
+    struct LeafJob
+    {
+        CRect rc;
+        std::array<double, 4> surface;
+        DWORD color;
+    };
+
+    // Folder overlay info collected during layout
+    struct FolderInfo
+    {
+        const CItem* item;
+        CRect rc;
+        int depth;
+        bool showHeader;
+    };
+
+    // Result of the UI-thread layout pass
+    struct LayoutResult
+    {
+        std::vector<COLORREF>   bitmapBits;
+        std::vector<LeafJob>    leafJobs;
+        std::vector<FolderInfo> folders;
+        CRect renderArea;           // inner rect after PrepareRenderArea shrinkage
+    };
+
+    // Create and draw a treemap (sync, UI thread)
     void DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* options = nullptr);
+
+    // UI-thread layout pass: sets TmiSetRectangle, resolves GetTextExtent for folder headers
+    LayoutResult BuildLayout(CDC* pdc, CRect rc, CItem* root, const Options* options = nullptr);
+
+    // Background-thread-safe: fills bitmapBits from leafJobs with par_unseq across leaves.
+    // progress is incremented after each leaf; cancel stops processing early when set.
+    void RenderLeafJobs(std::vector<COLORREF>& bitmapBits, const std::vector<LeafJob>& jobs,
+        std::atomic<int>* progress, const std::atomic<bool>* cancel) const;
+
+    // UI-thread: BlitBitmap + folder frames + extension labels
+    void DrawOverlays(CDC* pdc, const CRect& rc, CItem* root,
+        const std::vector<COLORREF>& bitmapBits, const std::vector<FolderInfo>& folders) const;
 
     // In the resulting treemap, find the item below a given coordinate.
     // Return value can be nullptr, iff point is outside root rect.

--- a/windirstat/Options.cpp
+++ b/windirstat/Options.cpp
@@ -76,6 +76,7 @@ Setting<bool> COptions::SkipDupeDetectionCloudLinks(OptionsGeneral, L"SkipDupeDe
 Setting<bool> COptions::ShowDupeDetectionCloudLinksWarning(OptionsGeneral, L"ShowDupeDetectionCloudLinksWarning", true);
 Setting<bool> COptions::AutoElevate(OptionsGeneral, L"AutoElevate", false);
 Setting<bool> COptions::AutoMapDrivesWhenElevated(OptionsGeneral, L"AutoMapDrivesWhenElevated", true);
+Setting<bool> COptions::TreeMapAsyncRendering(OptionsTreeMap, L"TreeMapAsyncRendering", false);
 Setting<bool> COptions::TreeMapGrid(OptionsTreeMap, L"TreeMapGrid", (CTreeMap::GetDefaults().grid));
 Setting<bool> COptions::TreeMapShowExtensions(OptionsTreeMap, L"TreeMapShowExtensions", (CTreeMap::GetDefaults().showExtensions));
 Setting<bool> COptions::TreeMapShowFolderFrames(OptionsTreeMap, L"TreeMapShowFolderFrames", (CTreeMap::GetDefaults().showFolderFrames));

--- a/windirstat/Options.h
+++ b/windirstat/Options.h
@@ -178,6 +178,7 @@ public:
     static Setting<bool> SkipDupeDetectionCloudLinks;
     static Setting<bool> ShowDupeDetectionCloudLinksWarning;
     static Setting<bool> AutoElevate;
+    static Setting<bool> TreeMapAsyncRendering;
     static Setting<bool> TreeMapGrid;
     static Setting<bool> TreeMapShowExtensions;
     static Setting<bool> TreeMapShowFolderFrames;

--- a/windirstat/Views/TreeMapView.cpp
+++ b/windirstat/Views/TreeMapView.cpp
@@ -168,7 +168,9 @@ void CTreeMapView::OnDraw(CDC* pDC)
             CSelectObject sobmp(&dcmem, &m_bitmap);
             m_treeMap.DrawOverlays(&dcmem, layout.renderArea, CWinDirStatModel::Get()->GetZoomItem(),
                                    layout.bitmapBits, layout.folders);
-            // fall through to BitBlt below
+            pDC->BitBlt(0, 0, m_size.cx, m_size.cy, &dcmem, 0, 0, SRCCOPY);
+            DrawHighlights(pDC);
+            return;
         }
         else
         {
@@ -238,9 +240,13 @@ void CTreeMapView::OnDraw(CDC* pDC)
         CSelectObject sobmp(&dcmem, &m_bitmap);
         if (CWinDirStatModel::Get()->IsZoomed()) DrawZoomFrame(&dcmem, rc);
         m_treeMap.DrawTreeMap(&dcmem, rc, CWinDirStatModel::Get()->GetZoomItem(), &COptions::TreeMapOptions);
+        pDC->BitBlt(0, 0, m_size.cx, m_size.cy, &dcmem, 0, 0, SRCCOPY);
+        DrawHighlights(pDC);
+        return;
     }
 
-    CSelectObject sobmp2(&dcmem, &m_bitmap);
+    // ── already drawn: plain repaint ───────────────────────────────────────
+    CSelectObject sobmp(&dcmem, &m_bitmap);
     pDC->BitBlt(0, 0, m_size.cx, m_size.cy, &dcmem, 0, 0, SRCCOPY);
     DrawHighlights(pDC);
 }
@@ -541,7 +547,19 @@ void CTreeMapView::EmptyView()
 void CTreeMapView::OnTimer(UINT_PTR nIDEvent)
 {
     if (nIDEvent == TIMER_RENDER_POLL)
-        Invalidate(FALSE); // OnDraw will check whether the future is ready
+    {
+        if (m_renderPending &&
+            m_renderFuture.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready)
+        {
+            // Render still running: only repaint the 3-pixel progress bar strip
+            CRect progressStrip(0, 0, m_size.cx, 3);
+            InvalidateRect(&progressStrip, FALSE);
+        }
+        else
+        {
+            Invalidate(FALSE); // render done: repaint full window to show result
+        }
+    }
     CWinDirStatPane::OnTimer(nIDEvent);
 }
 

--- a/windirstat/Views/TreeMapView.cpp
+++ b/windirstat/Views/TreeMapView.cpp
@@ -185,9 +185,8 @@ void CTreeMapView::OnDraw(CDC* pDC)
         const long long total = m_renderJobsTotal;
         if (total > 0 && done < total)
         {
-            const int w = static_cast<int>(done * rc.Width() / total);
-            if (w > 0)
-                pDC->FillSolidRect(CRect(0, 0, w, 3), RGB(0, 120, 215));
+            const int w = std::max(5, static_cast<int>(done * rc.Width() / total));
+            pDC->FillSolidRect(CRect(0, 0, w, 3), RGB(0, 120, 215));
         }
         return;
     }

--- a/windirstat/Views/TreeMapView.cpp
+++ b/windirstat/Views/TreeMapView.cpp
@@ -21,7 +21,10 @@
 
 IMPLEMENT_DYNCREATE(CTreeMapView, CWinDirStatPane)
 
+static constexpr UINT_PTR TIMER_RENDER_POLL = 1;
+
 BEGIN_MESSAGE_MAP(CTreeMapView, CWinDirStatPane)
+    ON_WM_TIMER()
     ON_WM_SIZE()
     ON_WM_LBUTTONDBLCLK()
     ON_WM_LBUTTONDOWN()
@@ -135,7 +138,7 @@ void CTreeMapView::DrawEmptyView(CDC* pDC)
     }
 }
 
-void CTreeMapView::OnDraw(CDC * pDC)
+void CTreeMapView::OnDraw(CDC* pDC)
 {
     const CItem* root = CWinDirStatModel::Get()->GetRootItem();
     if (root == nullptr || !root->IsDone() || m_drawingSuspended || !m_showTreeMap)
@@ -151,26 +154,95 @@ void CTreeMapView::OnDraw(CDC * pDC)
     CDC dcmem;
     dcmem.CreateCompatibleDC(pDC);
 
-    if (!IsDrawn())
+    // ── finalize a completed async render ──────────────────────────────────
+    if (m_renderPending &&
+        m_renderFuture.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready)
     {
-        CWaitCursor wc;
+        KillTimer(TIMER_RENDER_POLL);
+        auto layout = m_renderFuture.get();
+        m_renderPending = false;
 
-        m_bitmap.CreateCompatibleBitmap(pDC, m_size.cx, m_size.cy);
-
-        CSelectObject sobmp(&dcmem, &m_bitmap);
-
-        if (CWinDirStatModel::Get()->IsZoomed())
+        if (m_renderSize == m_size) // guard against resize during render
         {
-            DrawZoomFrame(&dcmem, rc);
+            // m_bitmap already has zoom frame + outer border from launch time
+            CSelectObject sobmp(&dcmem, &m_bitmap);
+            m_treeMap.DrawOverlays(&dcmem, layout.renderArea, CWinDirStatModel::Get()->GetZoomItem(),
+                                   layout.bitmapBits, layout.folders);
+            // fall through to BitBlt below
+        }
+        else
+        {
+            m_bitmap.DeleteObject(); // stale: wrong size; IsDrawn() → false → fresh render next frame
+            Invalidate(FALSE);
+            return;
+        }
+    }
+    // ── async render still running ─────────────────────────────────────────
+    else if (m_renderPending)
+    {
+        pDC->FillSolidRect(rc, RGB(0, 0, 0));
+        const long long done  = m_renderProgress->load(std::memory_order_relaxed);
+        const long long total = m_renderJobsTotal;
+        if (total > 0 && done < total)
+        {
+            const int w = static_cast<int>(done * rc.Width() / total);
+            if (w > 0)
+                pDC->FillSolidRect(CRect(0, 0, w, 3), RGB(0, 120, 215));
+        }
+        return;
+    }
+    // ── nothing drawn yet: launch render ───────────────────────────────────
+    else if (!IsDrawn())
+    {
+        if (COptions::TreeMapAsyncRendering)
+        {
+            // Create bitmap now so PrepareRenderArea can draw the outer border into it
+            m_bitmap.CreateCompatibleBitmap(pDC, m_size.cx, m_size.cy);
+            CSelectObject sobmp(&dcmem, &m_bitmap);
+            if (CWinDirStatModel::Get()->IsZoomed()) DrawZoomFrame(&dcmem, rc);
+
+            auto layout = m_treeMap.BuildLayout(&dcmem, rc,
+                CWinDirStatModel::Get()->GetZoomItem(), &COptions::TreeMapOptions);
+
+            if (layout.bitmapBits.empty())
+            {
+                m_bitmap.DeleteObject();
+                DrawEmptyView(pDC);
+                return;
+            }
+
+            m_renderJobsTotal = static_cast<int>(layout.leafJobs.size());
+            m_renderProgress  = std::make_shared<std::atomic<int>>(0);
+            m_renderCancel    = std::make_shared<std::atomic<bool>>(false);
+            m_renderSize      = m_size;
+            m_renderPending   = true;
+
+            CTreeMap treeMapCopy = m_treeMap;
+            auto prog   = m_renderProgress;
+            auto cancel = m_renderCancel;
+            m_renderFuture = std::async(std::launch::async,
+                [l = std::move(layout), tm = std::move(treeMapCopy), prog, cancel]() mutable
+                {
+                    tm.RenderLeafJobs(l.bitmapBits, l.leafJobs, prog.get(), cancel.get());
+                    return std::move(l);
+                });
+            SetTimer(TIMER_RENDER_POLL, 50, nullptr);
+
+            // Show empty frame while first render runs (progress bar at 0%)
+            pDC->FillSolidRect(rc, RGB(0, 0, 0));
+            return;
         }
 
+        // ── sync path ──────────────────────────────────────────────────────
+        CWaitCursor wc;
+        m_bitmap.CreateCompatibleBitmap(pDC, m_size.cx, m_size.cy);
+        CSelectObject sobmp(&dcmem, &m_bitmap);
+        if (CWinDirStatModel::Get()->IsZoomed()) DrawZoomFrame(&dcmem, rc);
         m_treeMap.DrawTreeMap(&dcmem, rc, CWinDirStatModel::Get()->GetZoomItem(), &COptions::TreeMapOptions);
     }
 
     CSelectObject sobmp2(&dcmem, &m_bitmap);
-
     pDC->BitBlt(0, 0, m_size.cx, m_size.cy, &dcmem, 0, 0, SRCCOPY);
-
     DrawHighlights(pDC);
 }
 
@@ -423,6 +495,7 @@ void CTreeMapView::Inactivate()
 {
     ClearHover();
     if (m_bitmap.m_hObject == nullptr) return;
+    if (m_renderPending) return; // async render owns m_bitmap; leave it intact
 
     // Move the old bitmap to m_dimmed for later dimmed display
     m_dimmed.DeleteObject();
@@ -446,6 +519,14 @@ void CTreeMapView::Inactivate()
 
 void CTreeMapView::EmptyView()
 {
+    if (m_renderPending)
+    {
+        m_renderCancel->store(true, std::memory_order_relaxed);
+        if (m_renderFuture.valid()) m_renderFuture.get(); // block until worker exits (fast: cancel flag set)
+        m_renderPending = false;
+        KillTimer(TIMER_RENDER_POLL);
+    }
+
     ClearHover();
     if (m_bitmap.m_hObject != nullptr)
     {
@@ -456,6 +537,13 @@ void CTreeMapView::EmptyView()
     {
         m_dimmed.DeleteObject();
     }
+}
+
+void CTreeMapView::OnTimer(UINT_PTR nIDEvent)
+{
+    if (nIDEvent == TIMER_RENDER_POLL)
+        Invalidate(FALSE); // OnDraw will check whether the future is ready
+    CWinDirStatPane::OnTimer(nIDEvent);
 }
 
 void CTreeMapView::OnSetFocus(CWnd* /*pOldWnd*/)

--- a/windirstat/Views/TreeMapView.h
+++ b/windirstat/Views/TreeMapView.h
@@ -77,7 +77,16 @@ protected:
     CSize m_dimmedSize{ 0,0 };        // Size of bitmap m_dimmed
     CBitmap m_dimmed;                 // Dimmed view. Used during refresh to avoid the ooops-effect.
 
+    // Async rendering state (only active when COptions::TreeMapAsyncRendering is true)
+    std::future<CTreeMap::LayoutResult> m_renderFuture;
+    std::shared_ptr<std::atomic<int>>  m_renderProgress;
+    std::shared_ptr<std::atomic<bool>> m_renderCancel;
+    int   m_renderJobsTotal = 0;
+    bool  m_renderPending   = false;
+    CSize m_renderSize;               // window size at async-render launch; used to detect stale results
+
     DECLARE_MESSAGE_MAP()
+    afx_msg void OnTimer(UINT_PTR nIDEvent);
     afx_msg void OnSize(UINT nType, int cx, int cy);
     afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
     afx_msg void OnMButtonDown(UINT nFlags, CPoint point);

--- a/windirstat/pch.h
+++ b/windirstat/pch.h
@@ -69,6 +69,7 @@
 #include <array>
 #include <atomic>
 #include <bit>
+#include <chrono>
 #include <cstdint>
 #include <cmath>
 #include <condition_variable>


### PR DESCRIPTION
> **Transparency notice:** I am not a professional programmer. This PR was developed with the assistance of an AI tool (Claude). I reviewed and tested the changes to the best of my ability. Please review carefully.

## Summary

Addresses #107 (CPU rendering path). A separate PR will cover the GPU path.

**Core optimizations (always active):**
- `DrawCushion`: `double` → `float` throughout; `#pragma float_control(precise, off, push/pop)` scoped to the function enables FMA fusion and `rsqrtss`+Newton-Raphson for `1/sqrtf` under `/fp:fast`
- New job-list architecture: `BuildLayout` (UI thread) collects `LeafJob` structs (rect + surface + color), then `RenderLeafJobs` processes them with `std::execution::par_unseq` across the full leaf list — better parallelism than per-row
- `DrawOverlays` extracted as a separate step (BlitBitmap + folder frames + extension labels)
- `DrawTreeMap` is now a thin sync wrapper calling all three

**Thread-safety note:** `BuildLayout` intentionally stays on the UI thread because `TmiSetRectangle` writes to the shared `CItem` tree, which `FindItemByPoint` reads on mouse-move. `RenderLeafJobs` only touches pixel memory and is safe on a background thread.

**Optional async render (`COptions::TreeMapAsyncRendering`, default `false`):**
- Layout runs on the UI thread; pixel shading is handed off to `std::async`
- While rendering: solid black background + 3px blue progress strip at top
- Cancel flag (`std::atomic<bool>`) shared via `shared_ptr` with the lambda — `EmptyView` sets it and drains the future before clearing bitmaps
- Resize during async: stale result detected via stored `m_renderSize`, discarded, fresh render triggered
- Maintainer opt-in: set registry key `HKCU\...\TreeMap\TreeMapAsyncRendering=1`

**Future work (comment in source):** SIMD (SSE4/AVX2) inner loop for `DrawCushion` — pros/cons documented in code; recommended to profile auto-vectorization output first.

## Test plan

- [ ] Sync path (`TreeMapAsyncRendering=0`): scan a large directory, verify treemap renders correctly with correct colors and folder frames
- [ ] Async path (`TreeMapAsyncRendering=1`): verify blue progress bar appears, treemap completes and displays correctly
- [ ] Resize during async render: resize window while rendering — should trigger fresh render without crash
- [ ] Cancel: close/reopen directory while async render in progress — `EmptyView` should drain cleanly without hang
- [ ] Zoom + highlight: verify hit-testing (`FindItemByPoint`) and selection still work after async render
- [ ] No regressions in KDirStat and SequoiaView layout styles

:robot: Generated with [Claude Code](https://claude.com/claude-code)
