### PR TITLE
feat: percentage columns respect logical size (fixes #455)

### DIFF
--- a/windirstat/Item.Extended.cpp
+++ b/windirstat/Item.Extended.cpp
@@ -85,9 +85,10 @@ bool CItem::DrawSubItem(const int subitem, CDC* pdc, CRect rc, const UINT state,
         // Walk to root and compute this item's fraction of the total tree size
         const CItem* root = this;
         while (root->GetParent() != nullptr) root = root->GetParent();
-        const ULONGLONG rootSize = root->GetSizePhysical();
+        const bool useLogical = COptions::TreeMapUseLogical;
+        const ULONGLONG rootSize = useLogical ? root->GetSizeLogical() : root->GetSizePhysical();
         const double absoluteFraction = rootSize == 0 ? 0.0 :
-            static_cast<double>(GetSizePhysical()) / static_cast<double>(rootSize);
+            static_cast<double>(useLogical ? GetSizeLogical() : GetSizePhysical()) / static_cast<double>(rootSize);
 
         // Derive palette for track, subtree bar, and absolute bar
         const COLORREF neutralBack  = dark ? RGB(40, 40, 40) : RGB(225, 225, 225);

--- a/windirstat/Item.cpp
+++ b/windirstat/Item.cpp
@@ -410,10 +410,15 @@ void CItem::UpwardSubtractFiles(const ULONG fileCount) noexcept
 
 double CItem::GetFraction() const noexcept
 {
-    if (!GetParent() || GetParent()->GetSizePhysical() == 0)
+    if (COptions::TreeMapUseLogical)
     {
-        return 1.0;
+        if (!GetParent() || GetParent()->GetSizeLogical() == 0)
+            return 1.0;
+        return static_cast<double>(GetSizeLogical()) /
+            static_cast<double>(GetParent()->GetSizeLogical());
     }
+    if (!GetParent() || GetParent()->GetSizePhysical() == 0)
+        return 1.0;
     return static_cast<double>(GetSizePhysical()) /
         static_cast<double>(GetParent()->GetSizePhysical());
 }


### PR DESCRIPTION
> **Transparency notice:** I am not a programmer. This contribution was developed with AI assistance (Claude Code). I reviewed and tested the result, but the implementation was largely AI-generated.

## Summary

Fixes #455

`COL_PERCENTAGE` (the subtree percentage column) and `COL_SIZE_PROPORTION` (the proportion bar) both used physical size for their calculations, even when **Options → Treemap → Use logical file size** was enabled. This caused the percentages shown in the folder tree to be inconsistent with the treemap view.

- `GetFraction()` now divides by logical size when `COptions::TreeMapUseLogical` is true
- The absolute-fraction overlay in the proportion bar uses the same toggle for consistency

**No new option is added** — the existing *Use logical file size* toggle controls both the treemap and the percentage columns, which feels natural: if you switch the treemap to logical size, the percentage numbers follow.

## Files changed

| File | Change |
|------|--------|
| `windirstat/Item.cpp` | `GetFraction()` branches on `TreeMapUseLogical` |
| `windirstat/Item.Extended.cpp` | `absoluteFraction` in proportion bar uses same toggle |

## Related

- Closes #455
- See also: #227 / PR #460 (adds *absolute* percentage columns — a complementary but separate feature)
