### PR TITLE
Address Crash On Open Filtering In Select Drives

### DIFF
--- a/windirstat/MainFrame.cpp
+++ b/windirstat/MainFrame.cpp
@@ -833,7 +833,7 @@ void CMainFrame::UpdateFrameTitleForScan(LPCWSTR scanName)
 
 BOOL CMainFrame::OnCmdMsg(UINT nID, int nCode, void* pExtra, AFX_CMDHANDLERINFO* pHandlerInfo)
 {
-    if (CWnd* focus = GetFocus())
+    if (CWnd* focus = GetFocus(); focus != nullptr && focus != this && this->IsChild(focus))
     {
         for (CWnd* target = focus; target != nullptr && target != this; target = target->GetParent())
         {


### PR DESCRIPTION
The regression was introduced in a59e03c5c03fedaedda00f58602902fe7495be66, when open Filtering page in Select Drives dialog, CMainFrame::OnCmdMsg would endless loop calling itself until stack overflow. 

```
     [Unhandled exception at 0x00007FF629C62288 in WinDirStat_x64.exe: 0xC00000FD: Stack overflow (parameters: 0x0000000000000001, 0x000000D2EA203FE8).]    
>    WinDirStat_x64.exe!CThreadSlotData::GetThreadValue(int nSlot) Line 275    C++
     WinDirStat_x64.exe!CThreadLocalObject::GetData(CNoTrackObject *(*)() pfnCreateObject=0x00007ff629beced8) Line 449    C++
     [Inline Frame] WinDirStat_x64.exe!CThreadLocal<_AFX_THREAD_STATE>::GetData() Line 183    C++
     [Inline Frame] WinDirStat_x64.exe!CThreadLocal<_AFX_THREAD_STATE>::operator class _AFX_THREAD_STATE *() Line 194    C++
     WinDirStat_x64.exe!AfxGetModuleState() Line 314    C++
     WinDirStat_x64.exe!AfxGetModuleThreadState() Line 356    C++
     WinDirStat_x64.exe!afxMapHWND(int bCreate=1) Line 306    C++
     WinDirStat_x64.exe!CWnd::FromHandle(HWND__ * hWnd=0x0000000000500f64) Line 326    C++
     [Inline Frame] WinDirStat_x64.exe!CWnd::GetFocus() Line 165    C++
     WinDirStat_x64.exe!CMainFrame::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 836    C++
     WinDirStat_x64.exe!CDialog::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 102    C++
     WinDirStat_x64.exe!CMainFrame::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 840    C++
     WinDirStat_x64.exe!CDialog::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 102    C++
     WinDirStat_x64.exe!CMainFrame::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 840    C++
     WinDirStat_x64.exe!CDialog::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 102    C++
     WinDirStat_x64.exe!CMainFrame::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 840    C++
     WinDirStat_x64.exe!CDialog::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 102    C++
     WinDirStat_x64.exe!CMainFrame::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 840    C++
     WinDirStat_x64.exe!CDialog::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 102    C++
     WinDirStat_x64.exe!CMainFrame::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 840    C++
     WinDirStat_x64.exe!CDialog::OnCmdMsg(unsigned int nID=57670, int nCode=0, void * pExtra=0x0000000000000000, AFX_CMDHANDLERINFO * pHandlerInfo=0x000000d2ea2fe190) Line 102    C++
...
```