### PR TITLE
Even Out Progress Bar Margin

### DIFF
--- a/windirstat/Dialogs/ProgressDlg.cpp
+++ b/windirstat/Dialogs/ProgressDlg.cpp
@@ -189,7 +189,7 @@ void CWdsProgressCtrl::OnPaint()
     progRect.DeflateRect(1, 1);
 
     CRgn clipRgn;
-    clipRgn.CreateRoundRectRgn(rect.left + 1, rect.top + 1, rect.right - 1, rect.bottom - 1, 2, 2);
+    clipRgn.CreateRoundRectRgn(rect.left + 2, rect.top + 2, rect.right - 1, rect.bottom - 1, 2, 2);
     dc.SelectClipRgn(&clipRgn);
 
     if (GetStyle() & PBS_MARQUEE)


### PR DESCRIPTION
Before

<img width="329" height="109" alt="image" src="https://github.com/user-attachments/assets/62f8d50b-e814-405d-9279-0e98be546e91" />

After

<img width="329" height="109" alt="image" src="https://github.com/user-attachments/assets/3fa71754-6d75-4395-a126-f72eaadb5066" />


