### PR TITLE
FileWatcher Minor UX Tweak

### DIFF
--- a/windirstat/Views/FileTabbedView.cpp
+++ b/windirstat/Views/FileTabbedView.cpp
@@ -132,8 +132,15 @@ void CFileTabbedView::SetSearchTabVisibility(const bool show)
 void CFileTabbedView::SetWatcherTabVisibility(const bool show)
 {
     GetTabControl().ShowTab(m_fileWatcherViewIndex, show);
-    if (show) CFileWatcherControl::Get()->StartMonitoring();
-    else CFileWatcherControl::Get()->StopMonitoring();
+    if (show)
+    {
+        CFileWatcherControl::Get()->StartMonitoring();
+    }
+    else
+    {
+        CFileWatcherControl::Get()->StopMonitoring();
+        CFileWatcherControl::Get()->DeleteAllItems();
+    }
 }
 
 void CFileTabbedView::SetPermsTabVisibility(const bool show)

--- a/windirstat/Views/FileTreeView.cpp
+++ b/windirstat/Views/FileTreeView.cpp
@@ -95,10 +95,10 @@ int CFileWatcherView::OnCreate(const LPCREATESTRUCT lpCreateStruct)
 
     // Columns should be in enumeration order so initial sort will work
     InsertCol(IDS_COL_NAME, LVCFMT_LEFT, 500, COL_ITEMWATCH_NAME);
-    InsertCol(IDS_COL_TIME, LVCFMT_LEFT, 110, COL_ITEMWATCH_TIME);
+    InsertCol(IDS_COL_TIME, LVCFMT_LEFT, 150, COL_ITEMWATCH_TIME);
     InsertCol(IDS_COL_OPERATION, LVCFMT_LEFT, 100, COL_ITEMWATCH_ACTION);
     InsertCol(IDS_COL_SIZE_LOGICAL, LVCFMT_RIGHT, 90, COL_ITEMWATCH_SIZE_LOGICAL);
-    m_control.SetSorting(COL_ITEMWATCH_TIME, false);
+    m_control.SetSorting(COL_ITEMWATCH_TIME, true);
 
     m_control.OnColumnsInserted();
 


### PR DESCRIPTION
- Change default width of Time column to show the timestamp in full out-of-the-box
- Change Time column sort sort in ascending order by default (older activity on top) to avoid scroll racing
- Configurable setting in Registry/INI for user to choose whether to retain the activity log or not on hiding FileWatcher view, enabled by default