### PR TITLE
Modernize GetLocaleString / Minor Refactoring

### DIFF
--- a/windirstat/HelpersInterface.cpp
+++ b/windirstat/HelpersInterface.cpp
@@ -44,11 +44,21 @@ static std::wstring FormatLongLongNormal(ULONGLONG n)
 
 std::wstring GetLocaleString(const LCTYPE lctype, const LCID lcid)
 {
-    const int len = ::GetLocaleInfo(lcid, lctype, nullptr, 0);
+    wchar_t name[LOCALE_NAME_MAX_LENGTH]{};
+    if (LCIDToLocaleName(lcid, name, LOCALE_NAME_MAX_LENGTH, LOCALE_ALLOW_NEUTRAL_NAMES) == 0) return {};
+
+    return GetLocaleString(lctype, name);
+}
+
+std::wstring GetLocaleString(const LCTYPE lctype, const std::wstring& localeName)
+{
+    if (localeName.empty()) return {};
+
+    const int len = GetLocaleInfoEx(localeName.c_str(), lctype, nullptr, 0);
     if (len <= 0) return {};
 
     std::wstring s(len - 1, L'\0');
-    ::GetLocaleInfo(lcid, lctype, s.data(), len);
+    GetLocaleInfoEx(localeName.c_str(), lctype, s.data(), len);
     return s;
 }
 

--- a/windirstat/HelpersInterface.h
+++ b/windirstat/HelpersInterface.h
@@ -23,6 +23,7 @@
 
 // Locale and formatting
 std::wstring GetLocaleString(LCTYPE lctype, LCID lcid);
+std::wstring GetLocaleString(const LCTYPE lctype, const std::wstring& localeName);
 std::wstring GetLocaleLanguage(LANGID langid);
 wchar_t GetLocaleThousandSeparator() noexcept;
 wchar_t GetLocaleDecimalSeparator() noexcept;

--- a/windirstat/Localization.cpp
+++ b/windirstat/Localization.cpp
@@ -102,15 +102,15 @@ std::set<LANGID> Localization::GetLanguageList()
     return results;
 }
 
-bool Localization::LoadResource(const WORD language)
+bool Localization::LoadResource(const LANGID language)
 {
-    // Load English strings first as a baseline fallback
+    const LCID lcid = MAKELCID(language, SORT_DEFAULT);
     const std::wstring sResourceData = GetTextResource(IDR_LANGS);
+
+    // Load English strings first as a baseline fallback
     CrackStrings(sResourceData, L"en");
 
-    const LCID lcid = MAKELCID(language, SORT_DEFAULT);
-    std::array<wchar_t, LOCALE_NAME_MAX_LENGTH> name{};
-    if (LCIDToLocaleName(lcid, name.data(), LOCALE_NAME_MAX_LENGTH, 0) == 0) return true;
+    if (GetLocaleInfo(lcid, LOCALE_SLANGUAGE, nullptr, 0) == 0) return true;
 
     // Short-circuit language resource loading sequence, first successful load will return true and exit the function
     return
@@ -199,10 +199,10 @@ void Localization::UpdateDialogs(CWnd& wnd)
 // Try to find and load external language file, return false if failed.
 bool Localization::LoadExternalLanguage(const LCTYPE lcttype, const LCID lcid)
 {
-    const std::wstring name = L"lang_" + GetLocaleString(lcttype, lcid) + L".txt";
+    const std::wstring filename = L"lang_" + GetLocaleString(lcttype, lcid) + L".txt";
     const std::wstring langFolder = GetAppFolder() + L"\\";
 
-    return FinderBasic::DoesFileExist(langFolder, name) && LoadFile(langFolder + name);
+    return FinderBasic::DoesFileExist(langFolder, filename) && LoadFile(langFolder + filename);
 }
 
 bool Localization::LoadFile(const std::wstring& file)

--- a/windirstat/Localization.h
+++ b/windirstat/Localization.h
@@ -73,7 +73,7 @@ public:
     static void UpdateDialogs(CWnd& wnd);
     static bool LoadExternalLanguage(LCTYPE lcttype, LCID lcid);
     static bool LoadFile(const std::wstring& file);
-    static bool LoadResource(WORD language);
+    static bool LoadResource(LANGID language);
     static std::wstring ConvertToWideString(const std::string_view& sv);
     static std::set<LANGID> GetLanguageList();
 };


### PR DESCRIPTION
- replace deprecated GetLocaleInfo with GetLocaleInfoEx for primary local information retrieval
- minor refactoring and lines rearrangement

As seen in the screenshot zh now correctly named `Chinese - 中文` as I expected
<img width="639" height="722" alt="image" src="https://github.com/user-attachments/assets/79abeed3-ead5-4d93-a6a2-a489e57aa088" />

Keep in mind this PR is only for GetLocaleString modernization, if any language files renaming needed, will leave it to another PR to maintain commit history readability.