### PR TITLE
Rearrange Layout Selection Popup

### DIFF
--- a/windirstat/LayoutPopup.cpp
+++ b/windirstat/LayoutPopup.cpp
@@ -24,65 +24,65 @@
 // Pane viewType: 0=AllFiles  1=FileTypes  2=TreeMap  -1=absent; x,y,w,h are fractions of card area
 const CLayoutPopup::LayoutDef CLayoutPopup::LAYOUTS[LAYOUT_COUNT] =
 {
-    // 0: [AF|FT] top half / TM bottom half
+    // 00: [AF|FT] top half / TM bottom half
     { { {0, 0.00f, 0.00f, 0.58f, 0.50f},
         {1, 0.58f, 0.00f, 0.42f, 0.50f},
         {2, 0.00f, 0.50f, 1.00f, 0.50f} }, LT_ROWS_SUB_COLS, 0 },
 
-    // 1: TM top half / [AF|FT] bottom half
-    { { {2, 0.00f, 0.00f, 1.00f, 0.50f},
-        {0, 0.00f, 0.50f, 0.58f, 0.50f},
-        {1, 0.58f, 0.50f, 0.42f, 0.50f} }, LT_ROWS_SUB_COLS, 1 },
-
-    // 2: AF(40) | TM(40) | FT(20) columns
-    { { {0, 0.00f, 0.00f, 0.40f, 1.00f},
-        {2, 0.40f, 0.00f, 0.40f, 1.00f},
-        {1, 0.80f, 0.00f, 0.20f, 1.00f} }, LT_COLS_THREE, 0 },
-
-    // 3: TM(40) | AF(40) | FT(20) columns
-    { { {2, 0.00f, 0.00f, 0.40f, 1.00f},
-        {0, 0.40f, 0.00f, 0.40f, 1.00f},
-        {1, 0.80f, 0.00f, 0.20f, 1.00f} }, LT_COLS_THREE, 1 },
-
-    // 4: AF(40) | FT(20) | TM(40) columns
+    // 04: AF(40) | FT(20) | TM(40) columns
     { { {0, 0.00f, 0.00f, 0.40f, 1.00f},
         {1, 0.40f, 0.00f, 0.20f, 1.00f},
         {2, 0.60f, 0.00f, 0.40f, 1.00f} }, LT_COLS_THREE, 2 },
 
-    // 5: TM(40) | FT(20) | AF(40) columns
+    // 05: TM(40) | AF(40) | FT(20) columns
+    { { {2, 0.00f, 0.00f, 0.40f, 1.00f},
+        {0, 0.40f, 0.00f, 0.40f, 1.00f},
+        {1, 0.80f, 0.00f, 0.20f, 1.00f} }, LT_COLS_THREE, 1 },
+
+    // 03: TM top half / [AF|FT] bottom half
+    { { {2, 0.00f, 0.00f, 1.00f, 0.50f},
+        {0, 0.00f, 0.50f, 0.58f, 0.50f},
+        {1, 0.58f, 0.50f, 0.42f, 0.50f} }, LT_ROWS_SUB_COLS, 1 },
+
+    // 01: AF(40) | TM(40) | FT(20) columns
+    { { {0, 0.00f, 0.00f, 0.40f, 1.00f},
+        {2, 0.40f, 0.00f, 0.40f, 1.00f},
+        {1, 0.80f, 0.00f, 0.20f, 1.00f} }, LT_COLS_THREE, 0 },
+
+    // 02: TM(40) | FT(20) | AF(40) columns
     { { {2, 0.00f, 0.00f, 0.40f, 1.00f},
         {1, 0.40f, 0.00f, 0.20f, 1.00f},
         {0, 0.60f, 0.00f, 0.40f, 1.00f} }, LT_COLS_THREE, 3 },
 
-    // 6: left=[TM(top)/AF(bot)], right=FT
-    { { {2, 0.00f, 0.00f, 0.60f, 0.50f},
-        {0, 0.00f, 0.50f, 0.60f, 0.50f},
-        {1, 0.60f, 0.00f, 0.40f, 1.00f} }, LT_COLS_SUB_ROWS, 0 },
-
-    // 7: left=[AF(top)/TM(bot)], right=FT
+    // 06: left=[AF(top)/TM(bot)], right=FT
     { { {0, 0.00f, 0.00f, 0.60f, 0.50f},
         {2, 0.00f, 0.50f, 0.60f, 0.50f},
         {1, 0.60f, 0.00f, 0.40f, 1.00f} }, LT_COLS_SUB_ROWS, 1 },
 
-    // 8: left=TM, right=[FT(top)/AF(bot)]
-    { { {2, 0.00f, 0.00f, 0.50f, 1.00f},
-        {1, 0.50f, 0.00f, 0.50f, 0.50f},
-        {0, 0.50f, 0.50f, 0.50f, 0.50f} }, LT_COLS_TM_FULL, 0 },
+    // 07: left=[AF(top)/FT(bot)], right=TM
+    { { {0, 0.00f, 0.00f, 0.50f, 0.50f},
+        {1, 0.00f, 0.50f, 0.50f, 0.50f},
+        {2, 0.50f, 0.00f, 0.50f, 1.00f} }, LT_COLS_TM_FULL, 3 },
 
-    // 9: left=TM, right=[AF(top)/FT(bot)]
+    // 08: left=TM, right=[AF(top)/FT(bot)]
     { { {2, 0.00f, 0.00f, 0.50f, 1.00f},
         {0, 0.50f, 0.00f, 0.50f, 0.50f},
         {1, 0.50f, 0.50f, 0.50f, 0.50f} }, LT_COLS_TM_FULL, 1 },
+
+    // 09: left=[TM(top)/AF(bot)], right=FT
+    { { {2, 0.00f, 0.00f, 0.60f, 0.50f},
+        {0, 0.00f, 0.50f, 0.60f, 0.50f},
+        {1, 0.60f, 0.00f, 0.40f, 1.00f} }, LT_COLS_SUB_ROWS, 0 },
 
     // 10: left=[FT(top)/AF(bot)], right=TM
     { { {1, 0.00f, 0.00f, 0.50f, 0.50f},
         {0, 0.00f, 0.50f, 0.50f, 0.50f},
         {2, 0.50f, 0.00f, 0.50f, 1.00f} }, LT_COLS_TM_FULL, 2 },
 
-    // 11: left=[AF(top)/FT(bot)], right=TM
-    { { {0, 0.00f, 0.00f, 0.50f, 0.50f},
-        {1, 0.00f, 0.50f, 0.50f, 0.50f},
-        {2, 0.50f, 0.00f, 0.50f, 1.00f} }, LT_COLS_TM_FULL, 3 },
+    // 11: left=TM, right=[FT(top)/AF(bot)]
+    { { {2, 0.00f, 0.00f, 0.50f, 1.00f},
+        {1, 0.50f, 0.00f, 0.50f, 0.50f},
+        {0, 0.50f, 0.50f, 0.50f, 0.50f} }, LT_COLS_TM_FULL, 0 },
 };
 
 int CLayoutPopup::LayoutIndex(int topology, int permutation)


### PR DESCRIPTION
## Screenshots

<img width="628" height="496" alt="image" src="https://github.com/user-attachments/assets/d4e0392e-a549-434b-9b06-b951e2f46039" />

The grouping logic as follows:

<img width="628" height="496" alt="image" src="https://github.com/user-attachments/assets/39c3fc95-7f4b-4cd8-b21f-5a6cc5e94b12" />

## AI Generated Breakdown of the Grouping Logic

* **Top-Left Quadrant (Horizontal Full-Width Splits):**
This quadrant groups layouts that use full-width splits. In these configurations, one component (the Treemap or the combined list view) occupies a full horizontal band across the top or bottom of the window. This is the most "stacked" or "linear" arrangement, where elements are layered on top of each other along the Y-axis.
* **Top-Right Quadrant (Vertical Triple-Column Splits):**
This grouping focuses on layouts where the window is divided into three distinct vertical columns. By placing these side-by-side, you have grouped configurations that maximize horizontal space, which is typically ideal for widescreen monitors. This logic relies on the primary division being along the X-axis.
* **Bottom-Left Quadrant (Nested Mixed-Axis Splits):**
This quadrant collects layouts where one major section (usually taking up 60% of the screen) is split internally. These layouts are characterized by an asymmetric design where one element acts as a "sidebar" or "main" pane while the remaining space is divided horizontally.
* **Bottom-Right Quadrant (Complex Nested Splits):**
These layouts appear to follow a more complex subdivision logic where the screen is split into major left/right sections, and then further subdivided into smaller blocks. This group represents the most "tiled" configurations, where screen space is fragmented into smaller, more granular zones to balance visibility between the tree, the list, and the visualization.

## Force-push log

- a9e2884262ef6e9c597f22dff12458ff8b13558f rearrange the bottom left 4 layouts
- 52cba18fba22f0a0827458d4147b9c8de6cc77ec rearrange the top left 4 layouts
