### PR TITLE
Tweak Drive Names In Folder Frames

### DIFF
--- a/windirstat/Controls/FlameGraph.cpp
+++ b/windirstat/Controls/FlameGraph.cpp
@@ -454,7 +454,7 @@ void CFlameGraph::RenderLabel(CDC* pdc, const CItem* item, const CRect& rc,
 {
     if (rc.Width() < m_minLabelWidth || rc.Height() < m_minLabelHeight) return;
 
-    const auto name = item->GetNameView();
+    const auto name = item->GetNameView(true);
     if (name.empty()) return;
 
     const double brightness = CColorSpace::GetColorBrightness(color);

--- a/windirstat/Controls/TreeMap.cpp
+++ b/windirstat/Controls/TreeMap.cpp
@@ -596,10 +596,10 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
         if (m_options.showFolderFrames && !state.asRoot &&
             std::min(state.rc.Width(), state.rc.Height()) >= m_options.folderFramesDrawThreshold)
         {
-            std::wstring name = item->GetName();
+            std::wstring_view name = item->GetNameView(true);
             const int textWidth = state.rc.Width() - 8;
             const bool showHeader = (state.rc.Height() > headerHeight) &&
-                (pdc->GetTextExtent(name.c_str(), static_cast<int>(name.size())).cx <= textWidth);
+                (pdc->GetTextExtent(name.data(), static_cast<int>(name.size())).cx <= textWidth);
 
             foldersToDraw.push_back({ item, state.rc, state.depth, showHeader });
             state.rc.left += 1;
@@ -670,9 +670,9 @@ void CTreeMap::DrawTreeMap(CDC* pdc, CRect rc, CItem* root, const Options* optio
                     pdc->FillSolidRect(&rcHeader, headerColor);
 
                     CRect rcText(rcHeader.left + 3, rcHeader.top, rcHeader.right - 3, rcHeader.bottom);
-                    std::wstring name = folder.item->GetName();
+                    std::wstring_view name = folder.item->GetNameView(true);
                     pdc->SetTextColor(RGB(0, 0, 0));
-                    pdc->DrawText(name.c_str(), static_cast<int>(name.size()), &rcText,
+                    pdc->DrawText(name.data(), static_cast<int>(name.size()), &rcText,
                         DT_LEFT | DT_VCENTER | DT_SINGLELINE | DT_NOPREFIX);
                 }
             }

--- a/windirstat/Item.Extended.cpp
+++ b/windirstat/Item.Extended.cpp
@@ -170,11 +170,7 @@ std::wstring CItem::GetText(const int subitem) const
     }
 
     case COL_NAME:
-        if (IsTypeOrFlag(IT_DRIVE))
-        {
-            return std::wstring(GetNameView().substr(std::size(L"?:")));
-        }
-        return GetName();
+        return GetName(true);
 
     case COL_OWNER:
         if (IsTypeOrFlag(IT_FILE, IT_DIRECTORY))

--- a/windirstat/Item.cpp
+++ b/windirstat/Item.cpp
@@ -597,13 +597,17 @@ void CItem::SetName(const std::wstring_view name)
     m_name[m_nameLen] = L'\0';
 }
 
-std::wstring CItem::GetName() const noexcept
+std::wstring CItem::GetName(const bool stripDrivePrefix) const noexcept
 {
-    return { m_name.get(), m_nameLen };
+    return std::wstring(GetNameView(stripDrivePrefix));
 }
 
-std::wstring_view CItem::GetNameView() const noexcept
+std::wstring_view CItem::GetNameView(const bool stripDrivePrefix) const noexcept
 {
+    if (stripDrivePrefix && IsTypeOrFlag(IT_DRIVE))
+    {
+        return std::wstring_view(m_name.get(), m_nameLen).substr(std::size(L"?:"));
+    }
     return { m_name.get(), m_nameLen };
 }
 

--- a/windirstat/Item.h
+++ b/windirstat/Item.h
@@ -190,8 +190,8 @@ public:
 
     // Paths & Names
     void SetName(std::wstring_view name);
-    std::wstring GetName() const noexcept;
-    std::wstring_view GetNameView() const noexcept;
+    std::wstring GetName(const bool stripDrivePrefix = false) const noexcept;
+    std::wstring_view GetNameView(const bool stripDrivePrefix = false) const noexcept;
     bool HasExtension(std::wstring_view extension) const noexcept;
     std::wstring GetExtension() const;
     std::wstring GetPath() const;


### PR DESCRIPTION
- move strip drive prefix logic from GetText to GetNameView()
- change Folder Frames in TreeMap and Flame Graph to use GetNameView(true)
<img width="1920" height="1060" alt="image" src="https://github.com/user-attachments/assets/de05c760-8a72-4d4c-a8f8-e87e648d4372" />
<img width="1920" height="1060" alt="image" src="https://github.com/user-attachments/assets/488a3337-dbc9-4afc-be9e-2e83bae856ae" />

## Force-push log
- 95f04b7108bb23277beb617ba9f21c4c85b5d2b2 correcting the spacing
- 841500257dd67ba59bf2f801119c61fe91f571f3 change Folder Frames in Flame Graph to use GetNameView(true)
