### PR TITLE
Address Startup Elevation Prompt Choice Retention

### DIFF
--- a/windirstat/WinDirStat.cpp
+++ b/windirstat/WinDirStat.cpp
@@ -438,12 +438,14 @@ bool CDirStatApp::InitInstance()
     // Allow user to elevate if desired
     if (IsElevationAvailable() && COptions::ShowElevationPrompt && !hideApp)
     {
-        if (const auto [nID, isChecked] =
-            CMessageBoxDlg::Show(Localization::Lookup(IDS_ELEVATION_QUESTION), Localization::Lookup(IDS_DONT_SHOW_AGAIN),
-                false, MB_YESNO | MB_ICONQUESTION, m_pMainWnd);
-            (COptions::ShowElevationPrompt = !isChecked, nID == IDYES))
+        const auto [nID, isChecked] = CMessageBoxDlg::Show(Localization::Lookup(IDS_ELEVATION_QUESTION),
+            Localization::Lookup(IDS_DONT_SHOW_AGAIN),false, MB_YESNO | MB_ICONQUESTION, m_pMainWnd);
+
+        COptions::ShowElevationPrompt = !isChecked;
+        if (isChecked) COptions::AutoElevate = (nID == IDYES); // Remember the user's choice if the checkbox is checked
+
+        if (nID == IDYES)
         {
-            if (isChecked) COptions::AutoElevate = true;
             RunElevated(m_lpCmdLine);
             return false;
         }


### PR DESCRIPTION
Address the issue #652, which correct the startup elevation prompt logic as follows:

When `Do not show this message again `checkbox is checked
- Select Yes should enable Auto elevate on startup and suppress startup elevation prompt
- Select No should disable Auto elevate on startup and suppress startup elevation prompt

## QA status
- Passed manual GUI based test

<details><summary>Test plan used(Generated by Gemini Flash 3.6 Extended Thinking)</summary>
<p>

When **Show privileges elevation prompt** (`ShowElevationPrompt`) is enabled, it takes precedence over **Automatically elevate on startup** (`AutoElevate`). The startup prompt will always display as long as prompting is active, ignoring any background auto-elevation setting until the user explicitly suppresses the prompt.

---

### Baseline GUI Reset Procedure

Perform these steps before executing each test case to return the application to a known state:

1. Launch WinDirStat and open the Settings window (**Options** $\rightarrow$ **Configure WinDirStat...**).
2. In the **Prompts** tab, set **Show privileges elevation prompt** to **Checked**.
3. In the **General** tab, set **Automatically elevate on startup** to **Unchecked**.
4. Click **OK** and close the application.

---

### Test Case 1: Prompt Priority Over Auto-Elevate

**Objective:** Verify that when **Show privileges elevation prompt** is enabled, the prompt takes priority and displays on startup even if **Automatically elevate on startup** is also enabled in Settings.

**Execution Steps:**

1. Launch WinDirStat and open **Settings** (**Options** $\rightarrow$ **Configure WinDirStat...**).
2. In the **General** tab, set **Automatically elevate on startup** to **Checked**.
3. In the **Prompts** tab, verify **Show privileges elevation prompt** is **Checked**.
4. Click **OK** and close WinDirStat.
5. Launch WinDirStat again.

**Expected Results:**

* Because prompting has higher priority, the startup elevation dialog **displays** upon launch despite **Automatically elevate on startup** being checked.
* Clicking **Yes** or **No** allows the session to proceed normally according to the user's immediate button selection.

---

### Test Case 2: Suppress Prompt with Affirmative Selection ("Always Elevate")

**Objective:** Verify that checking "Do not show this message again" and clicking "Yes" suppresses the prompt and transfers execution control to auto-elevation on future launches.

**Execution Steps:**

1. Perform the **Baseline GUI Reset Procedure**.
2. Launch WinDirStat. When the elevation prompt appears, select **Do not show this message again** and click **Yes**.
3. Accept the UAC prompt if prompted.
4. Once the main window opens, open **Settings** (**Options** $\rightarrow$ **Configure WinDirStat...**).
5. Inspect the GUI settings:
* **Prompts** tab: Verify **Show privileges elevation prompt** is **Unchecked**.
* **General** tab: Verify **Automatically elevate on startup** is **Checked**.


6. Close WinDirStat and launch it a second time.

**Expected Results:**

* On step 5, the prompt is disabled and auto-elevation is enabled in Settings.
* On step 6, because the high-priority prompt is now suppressed (`ShowElevationPrompt = false`), the application evaluates `AutoElevate = true` and launches directly in an elevated session without displaying a dialog.

---

### Test Case 3: Suppress Prompt with Negative Selection ("Never Elevate")

**Objective:** Verify that checking "Do not show this message again" and clicking "No" suppresses the prompt and sets auto-elevation to false (resolving Issue #652).

**Execution Steps:**

1. Perform the **Baseline GUI Reset Procedure**.
2. Launch WinDirStat. When the elevation prompt appears, select **Do not show this message again** and click **No**.
3. Once the main window opens, open **Settings** (**Options** $\rightarrow$ **Configure WinDirStat...**).
4. Inspect the GUI settings:
* **Prompts** tab: Verify **Show privileges elevation prompt** is **Unchecked**.
* **General** tab: Verify **Automatically elevate on startup** is **Unchecked**.


5. Close WinDirStat and launch it a second time.

**Expected Results:**

* On step 4, both options are unchecked in Settings.
* On step 5, because the prompt is suppressed and auto-elevation is disabled, WinDirStat launches directly in a standard (non-elevated) session without displaying a dialog.

---

### Test Case 4: Temporary Selection without Suppression ("Yes" or "No")

**Objective:** Verify that clicking "Yes" or "No" without checking "Do not show this message again" applies only to the active session and does not alter saved settings or priority order.

**Execution Steps:**

1. Perform the **Baseline GUI Reset Procedure**.
2. Launch WinDirStat. Leave **Do not show this message again** **Unchecked** and click **Yes** (or **No**).
3. Open **Settings** (**Options** $\rightarrow$ **Configure WinDirStat...**).
4. Inspect the GUI settings:
* **Prompts** tab: Verify **Show privileges elevation prompt** remains **Checked**.
* **General** tab: Verify **Automatically elevate on startup** remains **Unchecked**.


5. Close WinDirStat and relaunch it.

**Expected Results:**

* The current session runs in the chosen mode (elevated for "Yes", non-elevated for "No").
* Settings remain untouched at their default baseline values.
* On step 5, the prompt displays again on relaunch because prompt priority remains active.

---

### Test Case 5: Restoring Elevation Prompt Priority via Settings GUI

**Objective:** Verify that manually re-enabling the elevation prompt in Settings restores prompt priority over any existing auto-elevation behavior.

**Execution Steps:**

1. Complete **Test Case 2** so that prompt suppression is active and auto-elevation is enabled.
2. Open **Settings** (**Options** $\rightarrow$ **Configure WinDirStat...**).
3. Navigate to the **Prompts** tab and set **Show privileges elevation prompt** to **Checked**.
4. Click **OK**, then close and relaunch WinDirStat.

**Expected Results:**

* Re-enabling the prompt restores its higher priority over `AutoElevate`.
* Upon relaunching, the startup elevation dialog displays immediately despite `AutoElevate` still being enabled in the General tab.
</p>
</details> 
